### PR TITLE
chore(lint): tomio2480/github-workflows v2.2.2 を取り込み

### DIFF
--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -4,15 +4,15 @@ name: Markdown Lint
 # 以下 2 箇所のみ利用者が書き換える：
 #   - `OWNER` を利用する github-workflows のオーナー名に置き換える．
 #     （tomio2480 を直接利用するなら OWNER → tomio2480．自分でフォークした場合は自分のユーザー名）
-#   - `@8382b97a883560c5e05dbd862babd1c8fc8d8994` を利用したい github-workflows のコミット SHA に置き換える．
+#   - `@<SHA>` を利用したい github-workflows のコミット SHA に置き換える．
 #
 # 参照先（@ 以降）の選び方：
-#   - 既定: `@8382b97a883560c5e05dbd862babd1c8fc8d8994 # v2` 形式で SHA pin とバージョンコメントを併記する．
+#   - 既定: `@<SHA> # v2` 形式で SHA pin とバージョンコメントを併記する．
 #     Dependabot が SHA とバージョンの両方を自動追随し，更新は PR で通知される．
 #     本テンプレはこの方式を推奨．
 #   - 代替 1: `@main` — 中央の最新 commit を即時反映．Dependabot による更新検知は働かない．
 #     中央 repo の書き換えが即時反映される点に同意できる場合のみ．
-#   - 代替 2: `@8382b97a883560c5e05dbd862babd1c8fc8d8994 # v2.0.0` 形式 — 完全不変．パッチ追随も止めて固定したい場合．
+#   - 代替 2: `@<SHA> # v2.0.0` 形式 — 完全不変．パッチ追随も止めて固定したい場合．
 #
 # v1 系（`@v1` / `@v1.0.0` 等）は self-detection bug により動作しません．
 # 必ず v2 以降を参照してください（詳細は中央 repo の README）．
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Markdown Lint via composite action
-        uses: tomio2480/github-workflows/.github/actions/markdown-lint@8382b97a883560c5e05dbd862babd1c8fc8d8994 # v2
+        uses: tomio2480/github-workflows/.github/actions/markdown-lint@c9846a9ab03d568599596bb93b08122c449088c3 # v2.2.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．


### PR DESCRIPTION
caller workflow の SHA pin を v2.2.2（中央 mutable major `v2` の現在地）へ更新する設定変更のみ．本文・コード・テストの編集なし．self-reviewer 起動は省略．

## Summary

中央 lint テンプレート [tomio2480/github-workflows](https://github.com/tomio2480/github-workflows) が v2.2.2 までリリースされた．本リポジトリは caller-side の設定 3 ファイルを配置していないため，SHA 更新のみで中央 v2.2.2 の lint 改善が反映される．

### v2.2.2 までの主な改善（caller への影響）

- **v2.1.0 PR #16**：prh の「JS → JavaScript」ルールを `/\bJS\b/` の word boundary 付きへ修正．`json` ／ `JSON` ／ `--format json` への誤反応が解消
- **v2.1.0 PR #17**：caller-side `.textlint-allowlist.yml` 機能追加（必要時に caller で導入）
- **v2.2.0 PR #23**：全角記号 4 種（`・` `／` `：` `〜`）前後の半角スペース禁止 prh ルールを追加
- **v2.2.1 / v2.2.2**：doc-only

## 本 PR の変更

`.github/workflows/md-lint.yml` の SHA を `8382b97...`（v2 初期）から `c9846a9...`（v2.2.2）へ．バージョン comment を `# v2.2.2` に明示．

## Test plan

- [x] 変更が caller workflow の SHA pin とコメントのみであることを確認
- [ ] CI（Markdown Lint）で既存ドキュメントへの新規指摘が出るかを確認

## 期待する効果

- [#8](https://github.com/tomio2480/blog-pipeline/pull/8) で `JSON` 表記が prh で誤反応していた件が解消
- 全角記号前後の半角スペースが機械検出可能

## 参照

- 中央リリース：[tomio2480/github-workflows v2.2.2](https://github.com/tomio2480/github-workflows/releases/tag/v2.2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)