### PR TITLE
fix(list_materials): ダブルクォート内エスケープを JSON decode で処理する

### DIFF
--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -58,13 +58,19 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
         # コメント除去（ # 以降）
         # ただしクォート内の # は除去しない
         if raw_val.startswith('"') or raw_val.startswith("'"):
-            # クォートあり：終了クォートまでを値とする
             quote_char = raw_val[0]
-            end_idx = raw_val.find(quote_char, 1)
-            if end_idx != -1:
-                value: Any = raw_val[1:end_idx]
+            if quote_char == '"':
+                # ダブルクォート：JSON 文字列として解析し \" や \n 等を処理する
+                try:
+                    value: Any
+                    value, _ = json.JSONDecoder().raw_decode(raw_val)
+                except json.JSONDecodeError:
+                    end_idx = raw_val.find(quote_char, 1)
+                    value = raw_val[1:end_idx] if end_idx != -1 else raw_val[1:]
             else:
-                value = raw_val[1:]
+                # シングルクォート：エスケープなしで終了クォートを探す
+                end_idx = raw_val.find(quote_char, 1)
+                value = raw_val[1:end_idx] if end_idx != -1 else raw_val[1:]
             result[key] = value
             i += 1
         elif raw_val.startswith("["):

--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -59,16 +59,16 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
         # ただしクォート内の # は除去しない
         if raw_val.startswith('"') or raw_val.startswith("'"):
             quote_char = raw_val[0]
+            value = None
             if quote_char == '"':
                 # ダブルクォート：JSON 文字列として解析し \" や \n 等を処理する
                 try:
-                    value: Any
                     value, _ = json.JSONDecoder().raw_decode(raw_val)
                 except json.JSONDecodeError:
-                    end_idx = raw_val.find(quote_char, 1)
-                    value = raw_val[1:end_idx] if end_idx != -1 else raw_val[1:]
-            else:
-                # シングルクォート：エスケープなしで終了クォートを探す
+                    pass
+
+            if value is None:
+                # シングルクォートまたは解析失敗時：エスケープなしで終了クォートを探す
                 end_idx = raw_val.find(quote_char, 1)
                 value = raw_val[1:end_idx] if end_idx != -1 else raw_val[1:]
             result[key] = value

--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -37,6 +37,7 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
     """
     result: dict[str, Any] = {}
     lines = text.splitlines()
+    decoder = json.JSONDecoder()
     i = 0
     while i < len(lines):
         line = lines[i]
@@ -63,7 +64,7 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
             if quote_char == '"':
                 # ダブルクォート：JSON 文字列として解析し \" や \n 等を処理する
                 try:
-                    value, _ = json.JSONDecoder().raw_decode(raw_val)
+                    value, _ = decoder.raw_decode(raw_val)
                 except json.JSONDecodeError:
                     pass
 

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -1,6 +1,6 @@
 """list_materials.py のテスト．TDD（Red-Green-Refactor）で実装する．
 
-必須テストケース 4 種 + 追加テスト 4 種の計 8 テストを含む．
+テストケース 23 件を含む．
 """
 
 from __future__ import annotations
@@ -438,4 +438,48 @@ def test_quoted_value_with_backslash_n_parses_correctly() -> None:
 
     assert result["summary"] == "line1\nline2", (
         f"\\n エスケープが改行文字にならなかった: {result['summary']!r}"
+    )
+
+
+def test_quoted_value_with_escaped_backslash_parses_correctly() -> None:
+    r"""ダブルクォート内の \\ が単一バックスラッシュとして解析される（Issue #10）．
+    summary: "path\\to\\file" → 値が 'path\to\file' になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = r'summary: "path\\to\\file"'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["summary"] == r"path\to\file", (
+        f"エスケープ済みバックスラッシュが正しく解析されなかった: {result['summary']!r}"
+    )
+
+
+def test_quoted_value_with_yaml_only_escape_falls_back_to_find() -> None:
+    r"""JSON 不正なエスケープ（\a 等）は find ベースのフォールバックで処理される（Issue #10）．
+    YAML では \a はベル文字だが JSON では未定義のため JSONDecodeError が発生し，
+    フォールバックにより raw_val の find() で終端クォートを探して値を返す．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = r'summary: "\a"'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["summary"] == r"\a", (
+        f"フォールバック経路の戻り値が期待と異なる: {result['summary']!r}"
+    )
+
+
+def test_quoted_value_unterminated_falls_back_gracefully() -> None:
+    """終端クォートがない不正入力でもフォールバックが安全に値を返す（Issue #10）．
+    JSON デコードが失敗し，find() でも閉じクォートが見つからない場合は
+    raw_val[1:] を返す（開きクォートを除いた全体）．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'summary: "unterminated'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["summary"] == "unterminated", (
+        f"未終端入力のフォールバック結果が期待と異なる: {result['summary']!r}"
     )

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -408,3 +408,34 @@ def test_extract_frontmatter_does_not_swallow_keyboard_interrupt(
     text = "---\nfoo: bar\n---\n\n本文\n"
     with pytest.raises(KeyboardInterrupt):
         _extract_frontmatter(text)
+
+
+# ---------- Issue #10: クォート内エスケープ対応 ----------
+
+
+def test_quoted_value_with_escaped_quotes_parses_correctly() -> None:
+    """ダブルクォート内のエスケープ済みクォートが正しく解析される（Issue #10）．
+    summary: "Review of \\"The Book\\"" → 値が 'Review of "The Book"' になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'summary: "Review of \\"The Book\\""'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["summary"] == 'Review of "The Book"', (
+        f"エスケープ済みクォートが正しく解析されなかった: {result['summary']!r}"
+    )
+
+
+def test_quoted_value_with_backslash_n_parses_correctly() -> None:
+    """ダブルクォート内の \\n エスケープが改行文字として解析される（Issue #10）．
+    summary: "line1\\nline2" → 値が 'line1\\nline2'（改行文字含む）になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'summary: "line1\\nline2"'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["summary"] == "line1\nline2", (
+        f"\\n エスケープが改行文字にならなかった: {result['summary']!r}"
+    )

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -429,7 +429,7 @@ def test_quoted_value_with_escaped_quotes_parses_correctly() -> None:
 
 def test_quoted_value_with_backslash_n_parses_correctly() -> None:
     """ダブルクォート内の \\n エスケープが改行文字として解析される（Issue #10）．
-    summary: "line1\\nline2" → 値が 'line1\\nline2'（改行文字含む）になる．
+    summary: "line1\\nline2" → 改行を含む文字列になる．
     """
     from list_materials import _parse_simple_yaml
 


### PR DESCRIPTION
## 概要

`_parse_simple_yaml` のクォート値解析で `str.find()` を使っていたため，
`\"` や `\n` のエスケープシーケンスを含む値が途中で切れるバグを修正する．

## 修正内容

ダブルクォートで始まる値に対し，`json.JSONDecoder().raw_decode()` を使って
JSON 文字列としてデコードするよう変更した．

- `\"` → `"`（エスケープ済みクォート → リテラルクォート）
- `\n` → 改行文字（エスケープ済み改行 → 改行文字）

シングルクォートは従来どおり `find()` で処理する（YAML のシングルクォートは
JSON エスケープ規則と異なるため）．

`JSONDecodeError` 発生時は従来の `find()` 方式にフォールバックするため，
既存の動作が壊れない．

## テスト

TDD で実装した．失敗テスト 2 件を先に追加してから実装した．

- `test_quoted_value_with_escaped_quotes_parses_correctly`
- `test_quoted_value_with_backslash_n_parses_correctly`

既存 18 件＋新規 2 件，計 20 件すべて通過．

## 影響範囲

現状の `note-summarizer` 出力は制御下にあるため直近の運用への影響はない．
手書きや別ツール経由で `.summary.yml` を投入する場面への対応が主目的．

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)