### PR TITLE
docs: 実運用前のドキュメント齟齬を修正する

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,9 +92,9 @@ blog-pipeline/
 ├─ materials/                 素材置き場（.gitignore で除外．利用者がローカルで生成）
 │  ├─ raw/                    parse_enex.py が ENEX から書き出す
 │  └─ corrected/              transcript-corrector が校正したもの
-├─ .textlintrc.json           textlint 設定（Phase 4 で追加予定）
-├─ prh.yml                    prh 辞書（Phase 4 で追加予定）
-├─ .markdownlint-cli2.yaml    markdownlint 設定（Phase 4 で追加予定）
+├─ .textlintrc.json           textlint 設定
+├─ prh.yml                    prh 辞書
+├─ .markdownlint-cli2.yaml    markdownlint 設定
 ├─ LICENSE                    MIT
 └─ README.md
 ```
@@ -143,7 +143,7 @@ Skill はオーケストレーション役，Subagent は個別タスクの実�
 | 2 | `agent-templates/note-summarizer.md`，`agent-templates/note-tagger.md`，`list_materials.py`，`skill-templates/propose-articles/` | 完了 |
 | 3 | `agent-templates/article-proposer.md`，`agent-templates/article-drafter.md`，`skill-templates/structure-note/`，`skill-templates/writing-style/` のひな形 | 完了 |
 | 4 | `.textlintrc.json`，`prh.yml`，`.markdownlint-cli2.yaml` の汎用設定，`agent-templates/draft-reviewer.md`，`skill-templates/review-draft/`，`publish.py` | 一部完了（`agent-templates/draft-reviewer.md`／`skill-templates/review-draft/`／`publish.py` は実装済み；`textlint`／`prh`／`markdownlint` 汎用設定は未着手） |
-| 5 | `build_dictionary.py`，月次運用のドキュメント，CI・Skill チューニング | 未着手 |
+| 5 | `build_dictionary.py`，月次運用のドキュメント，CI・Skill チューニング | 完了 |
 
 各フェーズは GitHub Issue（`phase-N` ラベル）で管理する．フェーズ間で依存があれば Issue 本文に明記する．
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ Skill はオーケストレーション役，Subagent は個別タスクの実�
 | 1 | `parse_enex.py`，`agent-templates/transcript-corrector.md`，`materials/raw/` `materials/corrected/` の運用ガイド | 完了 |
 | 2 | `agent-templates/note-summarizer.md`，`agent-templates/note-tagger.md`，`list_materials.py`，`skill-templates/propose-articles/` | 完了 |
 | 3 | `agent-templates/article-proposer.md`，`agent-templates/article-drafter.md`，`skill-templates/structure-note/`，`skill-templates/writing-style/` のひな形 | 完了 |
-| 4 | `.textlintrc.json`，`prh.yml`，`.markdownlint-cli2.yaml` の汎用設定，`agent-templates/draft-reviewer.md`，`skill-templates/review-draft/`，`publish.py` | 一部完了（`agent-templates/draft-reviewer.md`／`skill-templates/review-draft/`／`publish.py` は実装済み；`textlint`／`prh`／`markdownlint` 汎用設定は未着手） |
+| 4 | `.textlintrc.json`，`prh.yml`，`.markdownlint-cli2.yaml` の汎用設定，`agent-templates/draft-reviewer.md`，`skill-templates/review-draft/`，`publish.py` | 完了 |
 | 5 | `build_dictionary.py`，月次運用のドキュメント，CI・Skill チューニング | 完了 |
 
 各フェーズは GitHub Issue（`phase-N` ラベル）で管理する．フェーズ間で依存があれば Issue 本文に明記する．

--- a/README.md
+++ b/README.md
@@ -103,9 +103,8 @@ python scripts/build_dictionary.py \
 出力先（デフォルト: `vocabulary/candidates.yml`）は毎回上書きされる．git 管理は不要．
 候補のレビューと `vocabulary.yml` への追記方法は `🗓 運用手順` の「月次辞書更新」節を参照のこと．
 
-月次辞書更新での素材ディレクトリは，デフォルトの `materials/raw/` ではなく
-補正済み素材 `materials/corrected/` を対象とすることを推奨する．
-その場合は `--materials materials/corrected` を明示すること．
+月次辞書更新では `materials/raw/` でなく `materials/corrected/` の使用を推奨する．
+明示する場合は `--materials materials/corrected` を指定すること．
 
 サンプルの `vocabulary.yml` は `examples/vocabulary.yml` を参照すること．
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@
 
 ## 🔧 セットアップ
 
-スクリプト本体は `scripts/` 配下にある．依存はサードパーティ非依存（標準ライブラリのみ）で実装するが，テストは `pytest` を使う．
+スクリプト本体は `scripts/` 配下にある．
+`parse_enex.py`・`list_materials.py`・`publish.py` は標準ライブラリのみで実装している．
+`build_dictionary.py` は形態素解析のため `janome` と `pyyaml` を使用する．
+テストは `pytest` を使う．
 
 ### Python 環境
 
@@ -100,7 +103,39 @@ python scripts/build_dictionary.py \
 出力先（デフォルト: `vocabulary/candidates.yml`）は毎回上書きされる．git 管理は不要．
 候補のレビューと `vocabulary.yml` への追記方法は `🗓 運用手順` の「月次辞書更新」節を参照のこと．
 
+月次辞書更新での素材ディレクトリは，デフォルトの `materials/raw/` ではなく
+補正済み素材 `materials/corrected/` を対象とすることを推奨する．
+その場合は `--materials materials/corrected` を明示すること．
+
 サンプルの `vocabulary.yml` は `examples/vocabulary.yml` を参照すること．
+
+### `list_materials.py` の使い方
+
+補正済み素材の一覧と要約・タグを JSON または Table 形式で取得する．
+
+```bash
+python scripts/list_materials.py materials/corrected/ --format json
+python scripts/list_materials.py materials/corrected/ --format table
+```
+
+`propose-articles` Skill はこのコマンドで素材一覧を取得する．
+
+### `publish.py` の使い方
+
+ドラフトをはてなブログへ下書き投稿する．以下の環境変数を `.env` ファイルに設定すること．
+
+| 変数名 | 説明 |
+|---|---|
+| `HATENA_USERNAME` | はてなユーザー名 |
+| `HATENA_BLOG_ID` | ブログ ID（例：`yourname.hatenablog.com`） |
+| `HATENA_API_KEY` | はてなブログ AtomPub API キー |
+
+```bash
+python scripts/publish.py drafts/2026-05-07-my-article.md
+python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.env
+```
+
+常に下書きとして投稿する．公開判断ははてなブログ管理画面で人間が行う．
 
 ### テスト
 

--- a/agent-templates/draft-reviewer.md
+++ b/agent-templates/draft-reviewer.md
@@ -6,7 +6,7 @@ model: sonnet
 
 # draft-reviewer
 
-`drafts/<YYYY-MM-DD>-<slug>.md` を受け取り，以下の観点でレビューを行います．機械校正（textlint）が通過した後に呼び出される前提です．textlint が検出済みの表記ゆれ・文末統一は再指摘しません．
+`drafts/<YYYY-MM-DD>-<slug>.md` を受け取り，以下の観点でレビューを行う．機械校正（textlint）が通過した後に呼び出される前提である．textlint が検出済みの表記ゆれ・文末統一は再指摘しない．
 
 ## 入力
 
@@ -14,7 +14,7 @@ model: sonnet
 
 ## 出力
 
-下記フォーマットで Markdown テキストを返します．問題がない場合は「指摘なし」と明記します．
+下記フォーマットで Markdown テキストを返す．問題がない場合は「指摘なし」と明記する．
 
 ```markdown
 ## レビュー結果

--- a/skill-templates/propose-articles/SKILL.md
+++ b/skill-templates/propose-articles/SKILL.md
@@ -60,6 +60,9 @@ python scripts/list_materials.py materials/corrected/ --format json
 - `summary`：既存の要約（無い場合は空文字列）
 - `auto_tags`：既存の自動推定タグ（無い場合は空配列）
 
+上記のほか，フロントマター由来の `source`・`updated`・`author`・`attachments` なども含まれる場合がある．
+クラスタリングでは `note_title`・`summary`・`tags`・`auto_tags` を主に参照すればよい．
+
 ### 2. 要約・タグ推定の補完
 
 `summary` または `auto_tags` が欠損している素材を抽出する．欠損がある場合は `note-summarizer`／`note-tagger` Subagent を **並列で起動** する．並列度の既定は 5 件以下．


### PR DESCRIPTION
## 概要

実運用開始前の最終確認として doc-syncer によるドキュメント齟齬チェックを実施し，
「使おうとして詰まる」箇所を中心に 7 件を修正した．

## 変更内容

### README.md
- 依存関係の記述を正確化：`build_dictionary.py` は `janome`・`pyyaml` を使用することを明記（「標準ライブラリのみ」は不正確だった）
- `build_dictionary.py` の月次運用時に `materials/corrected/` を推奨する旨を追記
- `list_materials.py` の CLI 使い方を追記
- `publish.py` の必要環境変数（`HATENA_*` 3 件）と実行例を追記

### ARCHITECTURE.md
- フェーズ 5 の状態を「未着手」→「完了」に修正
- lint 設定ファイル 3 件の「Phase 4 で追加予定」注記を削除（実装済み）

### `agent-templates/draft-reviewer.md`
- ます調をである調に統一（他の agent-templates と文体を揃える）

### `skill-templates/propose-articles/SKILL.md`
- `list_materials.py` 出力フィールドに追加フィールド（`source`・`updated` 等）の注記を追加

## Test plan

- [ ] textlint / markdownlint の CI が green になること