### PR TITLE
feat: Evernote AI 廃止を parse_enex と prompt-maker へ反映する

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,13 +42,9 @@
     ↓
 [Evernote 内蔵文字起こし]
     ↓
-[scripts/prompt-maker/generate_prompts.py]  Evernote AI プロンプト生成
-    ↓
-[Evernote AI 構造化（3 段階プロンプト投入）]
-    ↓
 [人間 ENEX エクスポート]
     ↓
-[parse_enex.py]  ENML → Markdown，メタ情報抽出
+[parse_enex.py]  ENML → Markdown，メタ情報抽出（2 セクション構成）
     ↓
 [materials/raw/*.md]
     ↓
@@ -70,7 +66,8 @@
 ```
 
 文字起こしは Evernote 内蔵の機能を利用する．
-構造化は `generate_prompts.py` が生成したプロンプトを Evernote AI に投入して行う（3 段階）．
+構造化・リンク整理・固有名詞校閲は `blog-private` 側の Claude Subagent が担当する．
+`generate_prompts.py` による Evernote AI への 3 段階プロンプト投入は 2026-06-12 に廃止した．
 素材は ENEX エクスポートで人間がリポジトリに橋渡しする．
 これにより whisper.cpp や Evernote API への依存を排し，利用者の準備コストを最小化する．
 
@@ -84,7 +81,7 @@ blog-pipeline/
 │  ├─ build_dictionary.py     形態素解析で固有名詞辞書を更新
 │  ├─ publish.py              AtomPub 投稿（常に下書き）
 │  └─ prompt-maker/
-│     ├─ generate_prompts.py  Evernote AI プロンプト生成
+│     ├─ generate_prompts.py  Evernote AI プロンプト生成（非推奨，2026-06-12 廃止）
 │     ├─ test_generate_prompts.py
 │     ├─ README.md
 │     └─ templates/           プロンプトテンプレート（3 段階）

--- a/README.md
+++ b/README.md
@@ -76,27 +76,13 @@ pip install -e ".[dev]"
 pip install pytest
 ```
 
-### `generate_prompts.py` の使い方
+### `generate_prompts.py` の使い方（非推奨）
 
-Evernote AI に投入する構造化プロンプトを 3 段階分生成する．
+> **非推奨．** 2026-06-12 の設計見直しで Evernote AI 構造化を廃止したため，
+> 本スクリプトは使用しない．詳細は `scripts/prompt-maker/README.md` を参照すること．
 
-```bash
-python scripts/prompt-maker/generate_prompts.py "2026-05-21-セッション名"
-```
-
-セッション識別子を渡すと，同名のディレクトリへ 3 ファイルが生成される．
-
-```
-2026-05-21-セッション名/
-├── 01_structure.md     # 文字起こし構造化プロンプト
-├── 02_links.md         # リンク整理・提案プロンプト
-└── 03_proper_nouns.md  # 固有名詞校閲プロンプト
-```
-
-生成したファイルを順に Evernote AI のチャットへ貼り付ける．
-各段階は別チャットで実行することを推奨する（Evernote AI のチャット長制限を回避するため）．
-
-詳細は `scripts/prompt-maker/README.md` を参照すること．
+Evernote AI に投入する構造化プロンプトを 3 段階分生成する CLI である．
+スクリプトとテンプレートは設計経緯の参照のため残置する．
 
 ### `parse_enex.py` の使い方
 
@@ -106,7 +92,11 @@ ENEX ファイルを Markdown へ変換する．
 python scripts/parse_enex.py path/to/export.enex --output-dir materials/raw
 ```
 
-出力は 1 ノート 1 ファイルで，フロントマター付き Markdown となる．3 セクション構成（🗒️ 人間メモ／🤖 Evernote AI 構造化情報／🗣️ 生の文字起こし）．ENEX 内の音声 base64 データは出力に含めない．
+出力は 1 ノート 1 ファイルで，フロントマター付き Markdown となる．
+原則 2 セクション構成（🗒️ 人間メモ／🗣️ 生の文字起こし）で出力する．
+`<h1>` を含む旧ノートは互換として
+🤖 Evernote AI 構造化情報セクションを人間メモと生の文字起こしの間に追加出力する（3 セクション構成）．
+ENEX 内の音声 base64 データは出力に含めない．
 
 ### `build_dictionary.py` の使い方
 

--- a/scripts/parse_enex.py
+++ b/scripts/parse_enex.py
@@ -119,7 +119,7 @@ def note_to_markdown(note: Note) -> str:
         parts.append(SECTION_AI_STRUCTURED)
         parts.append("")
         ai_md = enml_to_markdown(note.ai_structured_enml)
-        if ai_md:
+        if ai_md.strip():
             parts.append(ai_md)
         else:
             parts.append(EMPTY_AI_PLACEHOLDER)

--- a/scripts/parse_enex.py
+++ b/scripts/parse_enex.py
@@ -11,8 +11,10 @@
   実 ENEX は 1 ノート 30MB 程度であり実害軽微として iterparse 方式を採用する．
 - 出力ファイル名は NFC 正規化のうえ Windows 予約名・不正文字・末尾空白等を
   サニタイズし，最大 80 文字へ切り詰める．衝突時は `-2`，`-3` を付与する．
-- フロントマターは YAML で出力する．本文は 3 セクション構成
-  （人間メモ / Evernote AI 構造化情報 / 生の文字起こし）．
+- フロントマターは YAML で出力する．本文は原則 2 セクション構成
+  （人間メモ / 生の文字起こし）．
+  `<h1>` を含む旧ノートは互換として Evernote AI 構造化情報セクションを
+  人間メモと生の文字起こしの間に追加出力する（3 セクション構成）．
 
 使い方:
 
@@ -35,9 +37,9 @@ from typing import IO, Iterable, Iterator, Union
 
 
 SOURCE_NAME = "evernote"
-SECTION_HUMAN_MEMO = "## 🗒️ 人間メモ（音声と AI 構造化の間に書かれたもの）"
+SECTION_HUMAN_MEMO = "## 🗒️ 人間メモ（音声添付の後に書かれたもの）"
 SECTION_AI_STRUCTURED = "## 🤖 Evernote AI 構造化情報"
-SECTION_RAW_TRANSCRIPTION = "## 🗣️ 生の文字起こし（参考）"
+SECTION_RAW_TRANSCRIPTION = "## 🗣️ 生の文字起こし"
 EMPTY_AI_PLACEHOLDER = "（構造化情報なし）"
 MAX_FILENAME_STEM_LENGTH = 80
 WINDOWS_RESERVED_NAMES = {
@@ -98,7 +100,12 @@ def parse_enex(source: Source) -> Iterator[Note]:
 
 
 def note_to_markdown(note: Note) -> str:
-    """Note をフロントマター付き Markdown へ整形する．"""
+    """Note をフロントマター付き Markdown へ整形する．
+
+    h1 を含む旧ノートは 人間メモ／Evernote AI 構造化情報／生の文字起こし の
+    3 セクション構成とする（互換）．h1 を含まない新規ノートは
+    人間メモ／生の文字起こし の 2 セクション構成とする．
+    """
     parts: list[str] = [_yaml_frontmatter(note), ""]
 
     parts.append(SECTION_HUMAN_MEMO)
@@ -108,14 +115,15 @@ def note_to_markdown(note: Note) -> str:
         parts.append(memo_md)
         parts.append("")
 
-    parts.append(SECTION_AI_STRUCTURED)
-    parts.append("")
-    ai_md = enml_to_markdown(note.ai_structured_enml)
-    if ai_md:
-        parts.append(ai_md)
-    else:
-        parts.append(EMPTY_AI_PLACEHOLDER)
-    parts.append("")
+    if note.ai_structured_enml:
+        parts.append(SECTION_AI_STRUCTURED)
+        parts.append("")
+        ai_md = enml_to_markdown(note.ai_structured_enml)
+        if ai_md:
+            parts.append(ai_md)
+        else:
+            parts.append(EMPTY_AI_PLACEHOLDER)
+        parts.append("")
 
     parts.append(SECTION_RAW_TRANSCRIPTION)
     parts.append("")

--- a/scripts/prompt-maker/README.md
+++ b/scripts/prompt-maker/README.md
@@ -1,5 +1,14 @@
 # Evernote AI 文字起こし整理プロンプト生成 CLI
 
+> **非推奨（Deprecated）**
+>
+> 本スクリプトは 2026-06-12 の設計見直しにより非推奨となった．
+> Evernote AI による構造化を廃止し，構造化・リンク整理・固有名詞校閲の役割を
+> `blog-private` 側の Claude Subagent
+> （`transcript-corrector` / `article-proposer` / `article-drafter`）へ吸収した．
+> 3 種プロンプトの貼り付け往復という人間コストが節約効果に見合わないと判断した．
+> スクリプトとテンプレートは設計経緯の参照のため残置する．
+
 Evernote AI へ投入するプロンプトを，セッション識別子から自動生成する Python CLI．
 3 段階に分けた Markdown テンプレートへ値を埋め込み，識別子と同名のフォルダへ書き出す．
 

--- a/tests/test_parse_enex.py
+++ b/tests/test_parse_enex.py
@@ -57,8 +57,9 @@ def test_happy_transcription_extracted(happy_note: Note) -> None:
 
 
 def test_happy_markdown_three_sections_order(happy_note: Note) -> None:
+    """h1 ありノート（旧ノート）は 人間メモ → 🤖 AI 構造化 → 生の文字起こし の順で出力する．"""
     md = note_to_markdown(happy_note)
-    h1 = md.find("## 🗒️ 人間メモ")
+    h1 = md.find("## 🗒️ 人間メモ（音声添付の後に書かれたもの）")
     h2 = md.find("## 🤖 Evernote AI 構造化情報")
     h3 = md.find("## 🗣️ 生の文字起こし")
     assert 0 < h1 < h2 < h3
@@ -86,7 +87,7 @@ def test_happy_markdown_frontmatter_yaml_shape(happy_note: Note) -> None:
 
 def test_happy_markdown_human_memo_links(happy_note: Note) -> None:
     md = note_to_markdown(happy_note)
-    memo_start = md.index("## 🗒️ 人間メモ")
+    memo_start = md.index("## 🗒️ 人間メモ（音声添付の後に書かれたもの）")
     ai_start = md.index("## 🤖 Evernote AI 構造化情報")
     memo = md[memo_start:ai_start]
     assert "[イベントページ](https://example.com/event)" in memo
@@ -98,6 +99,7 @@ def test_happy_markdown_ai_structured(happy_note: Note) -> None:
     ai_start = md.index("## 🤖 Evernote AI 構造化情報")
     transcription_start = md.index("## 🗣️ 生の文字起こし")
     ai = md[ai_start:transcription_start]
+
     assert "# 登壇のテーマ" in ai
     assert "## 導入" in ai
     assert "## 本論" in ai
@@ -496,7 +498,11 @@ def test_no_transcription_yields_absent_state(tmp_path: Path) -> None:
     assert note.attachments == []
 
 
-def test_no_h1_yields_empty_ai_section(tmp_path: Path) -> None:
+def test_no_h1_yields_two_sections_only(tmp_path: Path) -> None:
+    """h1 なし（新規ノート）は 人間メモ・生の文字起こしの 2 セクションのみ出力する．
+
+    🤖 Evernote AI 構造化情報 見出しと（構造化情報なし）プレースホルダは出力しない．
+    """
     body = (
         '<en-note>'
         '<en-media style="--en-transcription:{&quot;segments&quot;:[{&quot;text&quot;:&quot;a&quot;}],&quot;transcription_state&quot;:&quot;transcribed&quot;,&quot;languages&quot;:[&quot;ja&quot;]};" hash="hhh" type="audio/mp4"/>'
@@ -507,11 +513,12 @@ def test_no_h1_yields_empty_ai_section(tmp_path: Path) -> None:
     path = _write_enex(tmp_path, enex)
     note = next(parse_enex(path))
     md = note_to_markdown(note)
-    ai_start = md.index("## 🤖 Evernote AI 構造化情報")
-    transcription_start = md.index("## 🗣️ 生の文字起こし")
-    ai = md[ai_start:transcription_start].strip()
-    body_only = ai.removeprefix("## 🤖 Evernote AI 構造化情報").strip()
-    assert body_only == "（構造化情報なし）"
+    human_memo_pos = md.find("## 🗒️ 人間メモ（音声添付の後に書かれたもの）")
+    transcription_pos = md.find("## 🗣️ 生の文字起こし")
+    assert human_memo_pos > 0
+    assert transcription_pos > human_memo_pos
+    assert "## 🤖 Evernote AI 構造化情報" not in md
+    assert "（構造化情報なし）" not in md
 
 
 def test_multiple_en_media_collected(tmp_path: Path) -> None:

--- a/tests/test_parse_enex.py
+++ b/tests/test_parse_enex.py
@@ -59,6 +59,9 @@ def test_happy_transcription_extracted(happy_note: Note) -> None:
 def test_happy_markdown_three_sections_order(happy_note: Note) -> None:
     """h1 ありノート（旧ノート）は 人間メモ → 🤖 AI 構造化 → 生の文字起こし の順で出力する．"""
     md = note_to_markdown(happy_note)
+    assert "## 🗒️ 人間メモ（音声添付の後に書かれたもの）" in md
+    assert "## 🤖 Evernote AI 構造化情報" in md
+    assert "## 🗣️ 生の文字起こし" in md
     h1 = md.find("## 🗒️ 人間メモ（音声添付の後に書かれたもの）")
     h2 = md.find("## 🤖 Evernote AI 構造化情報")
     h3 = md.find("## 🗣️ 生の文字起こし")
@@ -513,6 +516,8 @@ def test_no_h1_yields_two_sections_only(tmp_path: Path) -> None:
     path = _write_enex(tmp_path, enex)
     note = next(parse_enex(path))
     md = note_to_markdown(note)
+    assert "## 🗒️ 人間メモ（音声添付の後に書かれたもの）" in md
+    assert "## 🗣️ 生の文字起こし" in md
     human_memo_pos = md.find("## 🗒️ 人間メモ（音声添付の後に書かれたもの）")
     transcription_pos = md.find("## 🗣️ 生の文字起こし")
     assert human_memo_pos > 0


### PR DESCRIPTION
セルフコードレビュー実施済み（`self-reviewer` 一次走査と手動の差分確認）．

## 概要

2026-06-12 の設計見直し（Evernote AI 構造化の廃止）をフェーズ 6 として実装へ反映する．

## 変更内容

- `parse_enex.py`：Evernote AI の `<h1>` 挿入慣習への依存を解消し，2 セクション出力を既定とする
  - 人間メモ見出しを「🗒️ 人間メモ（音声添付の後に書かれたもの）」へ変更
  - 生の文字起こし見出しの「（参考）」サフィックスを削除
  - `<h1>` を含む旧ノートに限り，互換として「🤖 Evernote AI 構造化情報」セクションを従来位置に出力
  - `<h1>` がないノートでのプレースホルダ「（構造化情報なし）」出力を廃止
- `scripts/prompt-maker/`：deprecated 化．README 冒頭に経緯を明記し，コードとテストは経緯参照のため残置
- `README.md`／`ARCHITECTURE.md`：上記に伴う記述更新

## テスト

- `tests/`：159 passed（TDD：見出し変更と 2 セクション仕様のテストを先行追加し Red 3 件を確認後に実装）
- `scripts/prompt-maker/test_generate_prompts.py`：35 passed

## ドキュメント整合性

`README.md`・`ARCHITECTURE.md`・`scripts/prompt-maker/README.md` を同 PR 内で更新済み．

## 関連

- 設計判断の記録：`tomio2480/blog-private` の `docs/notes/2026-06-12-evernote-ai-retirement.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
