### PR TITLE
fix(parse_enex): 実 ENEX の --en-transcription を二段デコードと currentState スキーマで抽出する

### DIFF
--- a/scripts/parse_enex.py
+++ b/scripts/parse_enex.py
@@ -172,8 +172,18 @@ def write_notes(notes: Iterable[Note], output_dir: Path) -> list[Path]:
 def extract_transcription(en_media_style: str) -> tuple[str, str, list[str]]:
     """`--en-transcription` JSON から (連結テキスト, 状態, languages) を返す．
 
-    json.JSONDecoder().raw_decode() を使い，先頭から有効な JSON オブジェクトのみを
-    切り出す．JSON 文字列値内に `}` が含まれる場合も誤って切断しない．
+    json.JSONDecoder().raw_decode() を使い，先頭から有効な JSON 値のみを切り出す．
+    JSON 文字列値内に `}` が含まれる場合も誤って切断しない．
+
+    実 ENEX 形式では値が JSON 文字列でラップされている場合がある
+    （例: `"{\\"currentState\\":...}"` 形式）．raw_decode の戻り値が str の場合は
+    json.loads でもう 1 段デコードする．
+
+    スキーマ優先順位：
+    1. `currentState.state` / `currentState.transcribedLanguages`（実 ENEX 形式）
+    2. トップレベルの `transcription_state` / `languages`（旧形式・フォールバック）
+
+    いずれのデコードにも失敗した場合は ("", "absent", []) を返す．
     """
     if not en_media_style:
         return "", "absent", []
@@ -183,13 +193,31 @@ def extract_transcription(en_media_style: str) -> tuple[str, str, list[str]]:
         return "", "absent", []
     rest = en_media_style[idx + len(marker):].lstrip()
     try:
-        data, _ = json.JSONDecoder().raw_decode(rest)
+        parsed, _ = json.JSONDecoder().raw_decode(rest)
     except json.JSONDecodeError:
         return "", "absent", []
+
+    # 二段デコード：raw_decode の戻り値が str の場合（JSON 文字列ラップ形式）
+    if isinstance(parsed, str):
+        try:
+            data = json.loads(parsed)
+        except json.JSONDecodeError:
+            return "", "absent", []
+    else:
+        data = parsed
+
     if not isinstance(data, dict):
         return "", "absent", []
-    state = str(data.get("transcription_state", "absent"))
-    raw_languages = data.get("languages", [])
+
+    # currentState スキーマ（実 ENEX 形式）を優先，なければ旧形式にフォールバック
+    current_state = data.get("currentState")
+    if isinstance(current_state, dict):
+        state = str(current_state.get("state", "absent"))
+        raw_languages = current_state.get("transcribedLanguages", [])
+    else:
+        state = str(data.get("transcription_state", "absent"))
+        raw_languages = data.get("languages", [])
+
     languages = (
         [str(lang) for lang in raw_languages if lang is not None]
         if isinstance(raw_languages, list)

--- a/scripts/parse_enex.py
+++ b/scripts/parse_enex.py
@@ -212,11 +212,13 @@ def extract_transcription(en_media_style: str) -> tuple[str, str, list[str]]:
     # currentState スキーマ（実 ENEX 形式）を優先，なければ旧形式にフォールバック
     current_state = data.get("currentState")
     if isinstance(current_state, dict):
-        state = str(current_state.get("state", "absent"))
+        state_val = current_state.get("state")
         raw_languages = current_state.get("transcribedLanguages", [])
     else:
-        state = str(data.get("transcription_state", "absent"))
+        state_val = data.get("transcription_state")
         raw_languages = data.get("languages", [])
+    # キー不在と明示的な null をともに absent へ畳む（str(None) の "None" 漏れ防止）
+    state = str(state_val) if state_val is not None else "absent"
 
     languages = (
         [str(lang) for lang in raw_languages if lang is not None]

--- a/tests/fixtures/real-transcription-sample.enex
+++ b/tests/fixtures/real-transcription-sample.enex
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20260613T000000Z" application="Evernote" version="10.0">
+  <note>
+    <title>架空パイロット録音メモ</title>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+<en-note>
+<en-media style="--en-transcription:&quot;{\&quot;currentState\&quot;:{\&quot;state\&quot;:\&quot;transcribed\&quot;,\&quot;transcribedLanguages\&quot;:[\&quot;ja\&quot;]},\&quot;segments\&quot;:[{\&quot;text\&quot;:\&quot;架空の発話テスト一\&quot;},{\&quot;text\&quot;:\&quot;架空の発話テスト二\&quot;}]}&quot;;" hash="def1234567890abcdef1234567890abcd" type="audio/mp4"/>
+<div>架空のメモ本文．</div>
+</en-note>]]></content>
+    <created>20260613T100000Z</created>
+    <updated>20260613T100000Z</updated>
+    <tag>架空タグC</tag>
+    <note-attributes>
+      <author>bob</author>
+    </note-attributes>
+    <resource>
+      <data encoding="base64">AAECAwQFBgcICQoL</data>
+      <mime>audio/mp4</mime>
+      <resource-attributes>
+        <file-name>pilot.m4a</file-name>
+      </resource-attributes>
+    </resource>
+  </note>
+</en-export>

--- a/tests/test_parse_enex.py
+++ b/tests/test_parse_enex.py
@@ -211,6 +211,47 @@ def test_extract_transcription_handles_brace_inside_string() -> None:
     assert langs == ["ja"]
 
 
+# ---------- extract_transcription：実 ENEX 形式（currentState スキーマ）----------
+
+
+def test_extract_transcription_real_format_json_string_wrapped() -> None:
+    """JSON 文字列ラップ＋currentState スキーマで text/state/languages が取れること．"""
+    inner = (
+        '{"currentState":{"state":"transcribed","transcribedLanguages":["ja"]},'
+        '"segments":[{"text":"こんにちは"},{"text":"架空の発話"}]}'
+    )
+    import json as _json
+    wrapped = _json.dumps(inner)  # 二重エンコード: '"{\\"currentState\\":...}"'
+    style = f"--en-transcription:{wrapped};"
+    text, state, langs = extract_transcription(style)
+    assert "こんにちは" in text
+    assert "架空の発話" in text
+    assert state == "transcribed"
+    assert langs == ["ja"]
+
+
+def test_extract_transcription_real_format_dict_with_current_state() -> None:
+    """ラップなし dict でも currentState スキーマが読めること．"""
+    style = (
+        '--en-transcription:{"currentState":{"state":"transcribed",'
+        '"transcribedLanguages":["ja"]},'
+        '"segments":[{"text":"テスト発話"}]};'
+    )
+    text, state, langs = extract_transcription(style)
+    assert "テスト発話" in text
+    assert state == "transcribed"
+    assert langs == ["ja"]
+
+
+def test_extract_transcription_real_format_invalid_string_returns_absent() -> None:
+    """二段デコードに失敗する不正文字列は ("", "absent", []) を返すこと．"""
+    style = '--en-transcription:"not json";'
+    text, state, langs = extract_transcription(style)
+    assert text == ""
+    assert state == "absent"
+    assert langs == []
+
+
 def test_enml_nested_emphasis_preserved() -> None:
     enml = "<p>before<b>bold <i>italic</i></b>after</p>"
     out = enml_to_markdown(enml)
@@ -678,3 +719,31 @@ def test_multi_note_sample_created_dates_differ(multi_notes: list[Note]) -> None
     """3 件の note の created 日時が全て異なる．"""
     created_dates = [note.created for note in multi_notes]
     assert len(set(created_dates)) == 3
+
+
+# ---------- 統合テスト：実 ENEX 形式 real-transcription-sample.enex ----------
+
+
+@pytest.fixture(scope="module")
+def real_transcription_note() -> Note:
+    notes = list(parse_enex(FIXTURES / "real-transcription-sample.enex"))
+    assert len(notes) == 1
+    return notes[0]
+
+
+def test_real_transcription_state_is_transcribed(real_transcription_note: Note) -> None:
+    """実 ENEX 形式フィクスチャの transcription_state が 'transcribed' であること．"""
+    assert real_transcription_note.transcription_state == "transcribed"
+
+
+def test_real_transcription_languages_is_ja(real_transcription_note: Note) -> None:
+    """実 ENEX 形式フィクスチャの languages が ["ja"] であること．"""
+    assert real_transcription_note.languages == ["ja"]
+
+
+def test_real_transcription_text_contains_expected_phrases(
+    real_transcription_note: Note,
+) -> None:
+    """実 ENEX 形式フィクスチャの raw_transcription に期待文言が含まれること．"""
+    assert "架空の発話テスト一" in real_transcription_note.raw_transcription
+    assert "架空の発話テスト二" in real_transcription_note.raw_transcription

--- a/tests/test_parse_enex.py
+++ b/tests/test_parse_enex.py
@@ -243,6 +243,35 @@ def test_extract_transcription_real_format_dict_with_current_state() -> None:
     assert langs == ["ja"]
 
 
+def test_extract_transcription_real_format_null_state_returns_absent() -> None:
+    """currentState.state が明示的に null の場合は "None" ではなく absent を返すこと．"""
+    style = (
+        '--en-transcription:{"currentState":{"state":null,'
+        '"transcribedLanguages":["ja"]},"segments":[]};'
+    )
+    _, state, _ = extract_transcription(style)
+    assert state == "absent"
+
+
+def test_extract_transcription_legacy_null_state_returns_absent() -> None:
+    """旧形式の transcription_state が明示的に null でも absent を返すこと．"""
+    style = '--en-transcription:{"transcription_state":null,"segments":[]};'
+    _, state, _ = extract_transcription(style)
+    assert state == "absent"
+
+
+def test_extract_transcription_null_languages_returns_empty_list() -> None:
+    """transcribedLanguages が明示的に null でも languages は空リストになること．"""
+    style = (
+        '--en-transcription:{"currentState":{"state":"transcribed",'
+        '"transcribedLanguages":null},"segments":[{"text":"発話"}]};'
+    )
+    text, state, langs = extract_transcription(style)
+    assert text == "発話"
+    assert state == "transcribed"
+    assert langs == []
+
+
 def test_extract_transcription_real_format_invalid_string_returns_absent() -> None:
     """二段デコードに失敗する不正文字列は ("", "absent", []) を返すこと．"""
     style = '--en-transcription:"not json";'

--- a/tests/test_parse_enex.py
+++ b/tests/test_parse_enex.py
@@ -3,6 +3,7 @@ inline ENEX 文字列を一時ファイルへ書き出して検証する．"""
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -220,8 +221,7 @@ def test_extract_transcription_real_format_json_string_wrapped() -> None:
         '{"currentState":{"state":"transcribed","transcribedLanguages":["ja"]},'
         '"segments":[{"text":"こんにちは"},{"text":"架空の発話"}]}'
     )
-    import json as _json
-    wrapped = _json.dumps(inner)  # 二重エンコード: '"{\\"currentState\\":...}"'
+    wrapped = json.dumps(inner)  # 二重エンコード: '"{\\"currentState\\":...}"'
     style = f"--en-transcription:{wrapped};"
     text, state, langs = extract_transcription(style)
     assert "こんにちは" in text


### PR DESCRIPTION
セルフコードレビュー実施済み（`self-reviewer` 一次走査．指摘 1 件を反映，1 件は誤検知と判定）．

## 概要

実 ENEX の `--en-transcription` 属性を `parse_enex.py` が取りこぼし，
常に `transcription_state: "absent"` となる問題を修正する．

Closes #32

## 原因と修正

Issue #32 に記録した 2 点の前提齟齬へ対応した．

1. **JSON 文字列ラップ**：実 ENEX では属性値が `"{\"currentState\":...}"` 形式で
   ラップされている．`raw_decode()` の戻りが `str` の場合に `json.loads` で
   二段デコードする処理を追加した．
2. **スキーマの相違**：状態は `currentState.state`，言語は
   `currentState.transcribedLanguages` から読むよう変更した．
   旧形式のトップレベルキーへのフォールバックは合成フィクスチャ互換のため維持した．

`segments[].text` の抽出ロジックは実データも同一構造のため変更していない．

## テスト

TDD（Red-Green-Refactor）で実施した．

- Red：新規テスト 5 件の失敗を確認（既存テストは成功）
- Green / Refactor：全 165 件成功
- 追加テスト：ユニット 3 件（文字列ラップ・ラップなし `currentState`・不正文字列）＋
  実形式フィクスチャ `tests/fixtures/real-transcription-sample.enex` による統合 4 件

フィクスチャは架空データのみで構成し，個人情報・実在固有名詞を含まない．
`git diff --stat` でバイナリ表示されるのは `.gitattributes` の既存指定
（`*.enex binary`）によるもので，実体は通常のテキスト XML である．

## ドキュメント整合性

CLI の引数・出力仕様・フロントマターのキーに変更はなく，README の更新は不要と確認した．

## 発見の経緯

`blog-private` のフェーズ 6 STT パイロット（2026-06-12）で発見した．
詳細は `blog-private` の `docs/notes/2026-06-12-stt-pilot.md` を参照．

🤖 Generated with [Claude Code](https://claude.com/claude-code)