### PR TITLE
feat(list_materials): リスト要素のダブルクォートエスケープに対応する

### DIFF
--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -27,6 +27,32 @@ from typing import Any
 # ---------- YAML 限定パーサ ----------
 
 
+_JSON_DECODER = json.JSONDecoder()
+
+
+def _dequote_list_element(item_val: str) -> str:
+    """リスト要素のクォートを除去する．
+
+    - ダブルクォート始まりは JSON 文字列として解析し ``\\"`` や ``\\n`` 等のエスケープを処理する．
+      JSON として不正な場合は両端クォートのスライスにフォールバックする．
+    - シングルクォートはエスケープ処理せず両端のクォートのみ除去する．
+    - クォートなしはそのまま返す．
+    """
+    if item_val.startswith('"'):
+        try:
+            value, _ = _JSON_DECODER.raw_decode(item_val)
+            return value
+        except json.JSONDecodeError:
+            pass
+        # フォールバック：両端ダブルクォートなら単純スライス
+        if item_val.endswith('"') and len(item_val) >= 2:
+            return item_val[1:-1]
+        return item_val
+    if item_val.startswith("'") and item_val.endswith("'") and len(item_val) >= 2:
+        return item_val[1:-1]
+    return item_val
+
+
 def _parse_simple_yaml(text: str) -> dict[str, Any]:
     """ネスト無し・コメント無視の限定 YAML パーサ．
 
@@ -37,7 +63,6 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
     """
     result: dict[str, Any] = {}
     lines = text.splitlines()
-    decoder = json.JSONDecoder()
     i = 0
     while i < len(lines):
         line = lines[i]
@@ -64,7 +89,7 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
             if quote_char == '"':
                 # ダブルクォート：JSON 文字列として解析し \" や \n 等を処理する
                 try:
-                    value, _ = decoder.raw_decode(raw_val)
+                    value, _ = _JSON_DECODER.raw_decode(raw_val)
                 except json.JSONDecodeError:
                     pass
 
@@ -79,11 +104,10 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
             inner = raw_val.strip("[]")
             items_inline: list[str] = []
             for item_raw in inner.split(","):
-                item_val = item_raw.strip()
-                # クォート除去
-                if (item_val.startswith('"') and item_val.endswith('"')) or \
-                   (item_val.startswith("'") and item_val.endswith("'")):
-                    item_val = item_val[1:-1]
+                item_raw = item_raw.strip()
+                if not item_raw:
+                    continue
+                item_val = _dequote_list_element(item_raw)
                 if item_val:
                     items_inline.append(item_val)
             result[key] = items_inline
@@ -100,12 +124,7 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
                     continue
                 list_m = re.match(r'^\s+- (.*)', next_line)
                 if list_m:
-                    item_val = list_m.group(1).strip()
-                    # クォート除去
-                    if (item_val.startswith('"') and item_val.endswith('"')) or \
-                       (item_val.startswith("'") and item_val.endswith("'")):
-                        item_val = item_val[1:-1]
-                    items.append(item_val)
+                    items.append(_dequote_list_element(list_m.group(1).strip()))
                     i += 1
                 else:
                     break

--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -34,14 +34,18 @@ def _dequote_list_element(item_val: str) -> str:
     """リスト要素のクォートを除去する．
 
     - ダブルクォート始まりは JSON 文字列として解析し ``\\"`` や ``\\n`` 等のエスケープを処理する．
-      JSON として不正な場合は両端クォートのスライスにフォールバックする．
+      JSON として不正な場合，または閉じクォート後に余分なデータが残る場合は，
+      両端クォートのスライスにフォールバックする（値の切り捨てを防ぐ）．
     - シングルクォートはエスケープ処理せず両端のクォートのみ除去する．
     - クォートなしはそのまま返す．
     """
     if item_val.startswith('"'):
         try:
-            value, _ = _JSON_DECODER.raw_decode(item_val)
-            return value
+            value, end = _JSON_DECODER.raw_decode(item_val)
+            # 閉じクォート以降に余分なデータが無いときだけ採用する．
+            # ``"foo"bar`` のような不正要素を 'foo' へ丸めないため．
+            if item_val[end:].strip() == "":
+                return value
         except json.JSONDecodeError:
             pass
         # フォールバック：両端ダブルクォートなら単純スライス

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -1,6 +1,6 @@
 """list_materials.py のテスト．TDD（Red-Green-Refactor）で実装する．
 
-テストケース 29 件を含む．
+テストケース 31 件を含む．
 """
 
 from __future__ import annotations
@@ -565,4 +565,31 @@ def test_block_list_element_with_backslash_n_parses_correctly() -> None:
 
     assert result["auto_tags"] == ["line1\nline2"], (
         f"ブロックリストの \\n が改行文字にならなかった: {result['auto_tags']!r}"
+    )
+
+
+def test_inline_array_element_with_trailing_data_is_not_truncated() -> None:
+    """閉じクォートの後に余分なデータがある要素は値を切り捨てない（Codex レビュー指摘）．
+    tags: ["foo"bar] は不正な要素だが，raw_decode の戻り値 'foo' で丸めず，
+    従来どおりフォールバックで原文を保持する．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'tags: ["foo"bar]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ['"foo"bar'], (
+        f"閉じクォート後の余分なデータが切り捨てられた: {result['tags']!r}"
+    )
+
+
+def test_block_list_element_with_trailing_data_is_not_truncated() -> None:
+    """ブロックリストでも閉じクォート後の余分なデータを切り捨てない（Codex レビュー指摘）．"""
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'auto_tags:\n  - "foo"bar\n'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["auto_tags"] == ['"foo"bar'], (
+        f"閉じクォート後の余分なデータが切り捨てられた: {result['auto_tags']!r}"
     )

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -1,6 +1,6 @@
 """list_materials.py のテスト．TDD（Red-Green-Refactor）で実装する．
 
-テストケース 23 件を含む．
+テストケース 29 件を含む．
 """
 
 from __future__ import annotations
@@ -482,4 +482,87 @@ def test_quoted_value_unterminated_falls_back_gracefully() -> None:
 
     assert result["summary"] == "unterminated", (
         f"未終端入力のフォールバック結果が期待と異なる: {result['summary']!r}"
+    )
+
+
+# ---------- Issue #18: リスト要素のクォートエスケープ対応 ----------
+
+
+def test_inline_array_element_with_escaped_quote_parses_correctly() -> None:
+    """インライン配列の要素に含まれるエスケープ済みクォートが正しく解析される（Issue #18）．
+    tags: ["a\\"b", "c"] → ['a"b', 'c'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'tags: ["a\\"b", "c"]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ['a"b', "c"], (
+        f"インライン配列のエスケープ済みクォートが解析されなかった: {result['tags']!r}"
+    )
+
+
+def test_inline_array_element_with_backslash_n_parses_correctly() -> None:
+    """インライン配列の要素内 \\n が改行文字として解析される（Issue #18）．
+    tags: ["line1\\nline2"] → ['line1\nline2'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'tags: ["line1\\nline2"]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ["line1\nline2"], (
+        f"インライン配列の \\n が改行文字にならなかった: {result['tags']!r}"
+    )
+
+
+def test_inline_array_element_with_yaml_only_escape_falls_back_to_slice() -> None:
+    r"""JSON 不正なエスケープ（\a 等）はスライスのフォールバックで処理される（Issue #18）．
+    tags: ["\a"] → JSONDecodeError によりフォールバックし ['\a'] を返す．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = r'tags: ["\a"]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == [r"\a"], (
+        f"インライン配列のフォールバック結果が期待と異なる: {result['tags']!r}"
+    )
+
+
+def test_inline_array_single_quoted_element_keeps_literal(tmp_path: Path) -> None:
+    r"""シングルクォートの要素はエスケープ処理せず素のまま除去する（Issue #18）．
+    tags: ['a\nb'] → ['a\nb']（バックスラッシュ n が文字どおり残る）になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = r"tags: ['a\nb']"
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == [r"a\nb"], (
+        f"シングルクォート要素のリテラルが保持されなかった: {result['tags']!r}"
+    )
+
+
+def test_block_list_element_with_escaped_quote_parses_correctly() -> None:
+    """ブロックリストの要素に含まれるエスケープ済みクォートが正しく解析される（Issue #18）．"""
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'auto_tags:\n  - "tag\\"x"\n  - plain\n'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["auto_tags"] == ['tag"x', "plain"], (
+        f"ブロックリストのエスケープ済みクォートが解析されなかった: {result['auto_tags']!r}"
+    )
+
+
+def test_block_list_element_with_backslash_n_parses_correctly() -> None:
+    """ブロックリストの要素内 \\n が改行文字として解析される（Issue #18）．"""
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'auto_tags:\n  - "line1\\nline2"\n'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["auto_tags"] == ["line1\nline2"], (
+        f"ブロックリストの \\n が改行文字にならなかった: {result['auto_tags']!r}"
     )


### PR DESCRIPTION
## 概要

セルフコードレビュー実施済み（意図・デバッグ残骸・TDD 順序・命名・例外粒度・依存・差分量を確認）．

`_parse_simple_yaml` のスカラー値パスは既に `json.JSONDecoder().raw_decode()` でエスケープ処理していたが，インライン配列（`["tagA", "tagB"]`）とブロックリスト（`- item`）の要素は単純スライス（`item_val[1:-1]`）のままだった．本 PR で両者も同じエスケープ処理に揃える．

PR #15 の Gemini Code Assist レビュー（コメント 3232084669）で見送られたフォローアップ対応．

## 変更内容

- 共通ヘルパー `_dequote_list_element` を追加し，ダブルクォート始まりの要素は `raw_decode()` でエスケープ（`\"` や `\n` 等）を処理する．JSON として不正な場合は従来の単純スライスにフォールバックする．
- スカラー値パスとリスト要素パスで単一の `JSONDecoder` インスタンス（`_JSON_DECODER`）を共有する．
- シングルクォート要素・クォートなし要素・空要素の従来挙動は維持する．

## テスト（TDD: Red → Green → Refactor）

- 失敗テスト 6 件を先に追加（インライン配列・ブロックリストの `\"` / `\n` 解析，フォールバック，シングルクォートのリテラル保持）．
- 実装後，`tests/test_list_materials.py` は 29 件すべて通過．リポジトリ全体で 174 passed．

```
python -m pytest tests/test_list_materials.py -q
# 29 passed
```

## 補足

- CI は `md-lint`（Markdown）のみで Python linter は無いことを確認済み．
- 同ファイルに pre-existing な未使用 import（`io` / `sys`）があるが，本 PR のスコープ外として手を付けていない．

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
