### PR TITLE
feat(transcribe_audio): 音声直接取り込みの文字起こしスクリプトを新設する

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,30 @@ python scripts/parse_enex.py path/to/export.enex --output-dir materials/raw
 🤖 Evernote AI 構造化情報セクションを人間メモと生の文字起こしの間に追加出力する（3 セクション構成）．
 ENEX 内の音声 base64 データは出力に含めない．
 
+### `transcribe_audio.py` の使い方
+
+録音音声を `whisper.cpp` で文字起こしし，生の文字起こしテキストを出力する．
+フェーズ 7 で新設した音声直接取り込み経路の文字起こし工程を担う．
+`ffmpeg` で 16kHz モノラル WAV へ変換した上で `whisper.cpp` の `large-v3` を実行する．
+
+`whisper.cpp` のバイナリとモデルは環境依存のため，パスを環境変数で渡す．
+未設定なら明示エラーで停止する．
+
+```bash
+export WHISPER_CLI_PATH=/path/to/whisper-cli
+export WHISPER_MODEL_PATH=/path/to/ggml-large-v3.bin
+python scripts/transcribe_audio.py \
+  --audio path/to/2026-04-28-録音名.m4a \
+  --vocabulary path/to/vocabulary.yml \
+  --output-dir .scratch/transcription
+```
+
+ループ対策として `-mc 0`（直前文脈の持ち越し無効化）を標準化する．
+`vocabulary.yml` の canonical 語を `--prompt`（初期プロンプト）へ注入し，固有名詞の正答率を補助する．
+ただし初期プロンプトは soft hint であり，誤認識の残りは後段の `transcript-corrector` で補正する前提とする．
+入力音声と中間 WAV，生の文字起こしは再生成できるため `.scratch/` 配下など Git 管理外へ出力する．
+`ffmpeg` は PATH 上にある前提とする．
+
 ### `build_material.py` の使い方
 
 録音音声から得た生の文字起こしと，人が手書きした人間メモ Markdown を 1 つの素材へまとめる．

--- a/scripts/transcribe_audio.py
+++ b/scripts/transcribe_audio.py
@@ -97,6 +97,8 @@ def build_ffmpeg_command(input_path: Path, wav_path: Path) -> list[str]:
     """音声を 16kHz モノラルの PCM WAV へ変換する `ffmpeg` コマンドを組み立てる．"""
     return [
         "ffmpeg",
+        "-loglevel",
+        "error",
         "-i",
         str(input_path),
         "-ar",
@@ -135,6 +137,7 @@ def build_whisper_command(
         "-mc",
         "0",
         "-otxt",
+        "-np",
         "-of",
         str(output_stem),
     ]
@@ -230,7 +233,13 @@ def transcribe(
         prompt=prompt,
         language=language,
     )
-    if subprocess.run(whisper_cmd).returncode != 0:
+    try:
+        whisper_result = subprocess.run(whisper_cmd)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"whisper-cli が見つかりません．パスを確認してください: {whisper_cli}"
+        ) from exc
+    if whisper_result.returncode != 0:
         raise RuntimeError(f"whisper.cpp による文字起こしに失敗しました: {audio_path}")
 
     return output_dir / f"{stem}.txt"
@@ -274,6 +283,12 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     if not args.vocabulary.exists() or not args.vocabulary.is_file():
         print(f"辞書ファイルが見つかりません: {args.vocabulary}", file=sys.stderr)
+        return 2
+
+    # 明示指定した --env-file が存在しないときは黙ってフォールバックせず知らせる．
+    # 既定の .env は存在しなくても許容する．
+    if args.env_file != Path(".env") and not args.env_file.exists():
+        print(f"環境ファイルが見つかりません: {args.env_file}", file=sys.stderr)
         return 2
 
     # os.environ を .env より優先する（publish.py と同じ規約）．

--- a/scripts/transcribe_audio.py
+++ b/scripts/transcribe_audio.py
@@ -287,7 +287,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # 明示指定した --env-file が存在しないときは黙ってフォールバックせず知らせる．
     # 既定の .env は存在しなくても許容する．
-    if args.env_file != Path(".env") and not args.env_file.exists():
+    if args.env_file != Path(".env") and not args.env_file.is_file():
         print(f"環境ファイルが見つかりません: {args.env_file}", file=sys.stderr)
         return 2
 

--- a/scripts/transcribe_audio.py
+++ b/scripts/transcribe_audio.py
@@ -1,0 +1,299 @@
+"""録音音声から生の文字起こしテキストを得る CLI スクリプト．
+
+設計方針:
+
+- 録音音声を起点とする新しい取り込み経路（フェーズ 7）の文字起こし工程を担う．
+  `ffmpeg` で 16kHz モノラル WAV へ変換し，`whisper.cpp` の `large-v3` で
+  文字起こしする．生成テキストは `.scratch/` など Git 管理外の場所へ出力し，
+  後段の `build_material.py` が人間メモと束ねて素材 Markdown を生成する．
+- `whisper.cpp` のバイナリとモデルは環境依存のため，パスは環境変数
+  `WHISPER_CLI_PATH`／`WHISPER_MODEL_PATH` で受け取る．未設定なら fail fast する．
+  無言の代替動作を避ける（`code-quality` の silent fallback 回避）．
+- ループ対策として `-mc 0`（直前文脈の持ち越し無効化）を標準化する．
+  STT パイロット（2026-06-12）で 72 分録音のループ消失を確認した判断である．
+- 固有名詞の正答率を上げるため，`vocabulary.yml` の canonical 語を
+  `--prompt`（初期プロンプト）へ注入する．
+- 依存は `pyyaml` のみ（リポジトリ既定の依存）．`ffmpeg` は PATH 上を前提とする．
+
+使い方:
+
+    set WHISPER_CLI_PATH=C:\\path\\to\\whisper-cli.exe
+    set WHISPER_MODEL_PATH=C:\\path\\to\\ggml-large-v3.bin
+    python scripts/transcribe_audio.py --audio <materials/audio/録音.m4a> \\
+        --vocabulary <vocabulary.yml> --output-dir <.scratch/transcription>
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+
+# canonical 語を抽出する辞書カテゴリ（出現順を保つ）
+VOCABULARY_CATEGORIES = ("places", "organizations", "technical_terms")
+PROMPT_SEPARATOR = "、"
+ENV_WHISPER_CLI = "WHISPER_CLI_PATH"
+ENV_WHISPER_MODEL = "WHISPER_MODEL_PATH"
+DEFAULT_LANGUAGE = "ja"
+
+
+# ---------- prompt ----------
+
+
+def load_prompt_words(vocabulary_path: Path) -> str:
+    """`vocabulary.yml` の canonical 語を連結した初期プロンプト文字列を返す．
+
+    `places`／`organizations`／`technical_terms` の各 canonical を出現順に集め，
+    重複を除いて区切り文字で連結する．エントリが無ければ空文字列を返す．
+    """
+    if not vocabulary_path.exists():
+        raise ValueError(f"辞書ファイルが見つかりません: {vocabulary_path}")
+
+    data = yaml.safe_load(vocabulary_path.read_text(encoding="utf-8"))
+    if data is None:
+        return ""
+    if not isinstance(data, Mapping):
+        raise ValueError(
+            f"辞書のトップレベルはマッピングである必要があります: {vocabulary_path}"
+        )
+
+    words: list[str] = []
+    seen: set[str] = set()
+    for category in VOCABULARY_CATEGORIES:
+        entries = data.get(category)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                continue
+            canonical = entry.get("canonical")
+            if not isinstance(canonical, str):
+                continue
+            canonical = canonical.strip()
+            if not canonical or canonical in seen:
+                continue
+            seen.add(canonical)
+            words.append(canonical)
+
+    return PROMPT_SEPARATOR.join(words)
+
+
+# ---------- command builders ----------
+
+
+def build_ffmpeg_command(input_path: Path, wav_path: Path) -> list[str]:
+    """音声を 16kHz モノラルの PCM WAV へ変換する `ffmpeg` コマンドを組み立てる．"""
+    return [
+        "ffmpeg",
+        "-i",
+        str(input_path),
+        "-ar",
+        "16000",
+        "-ac",
+        "1",
+        "-c:a",
+        "pcm_s16le",
+        "-y",
+        str(wav_path),
+    ]
+
+
+def build_whisper_command(
+    whisper_cli: Path,
+    whisper_model: Path,
+    wav_path: Path,
+    output_stem: Path,
+    *,
+    prompt: str,
+    language: str,
+) -> list[str]:
+    """`whisper.cpp` 実行コマンドを組み立てる．
+
+    `-mc 0` を標準化し，`-otxt` でテキストを `output_stem`.txt へ出力する．
+    `prompt` が非空のときのみ `--prompt` を付与する．
+    """
+    cmd = [
+        str(whisper_cli),
+        "-m",
+        str(whisper_model),
+        "-f",
+        str(wav_path),
+        "-l",
+        language,
+        "-mc",
+        "0",
+        "-otxt",
+        "-of",
+        str(output_stem),
+    ]
+    if prompt:
+        cmd += ["--prompt", prompt]
+    return cmd
+
+
+# ---------- env ----------
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """シンプルな `.env` ファイルパーサー（`publish.py` と同じ規約）．
+
+    - `KEY=VALUE` 形式の行を読む．`#` 始まりの行は無視する．
+    - 値の前後のクォート（`"` / `'`）は除去する．
+    - `export KEY=VALUE` 形式も受け付ける．
+    """
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = re.sub(r"^export\s+", "", line)
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        if key:
+            env[key] = value
+    return env
+
+
+def resolve_whisper_paths(env: Mapping[str, str]) -> tuple[Path, Path]:
+    """環境変数から `whisper.cpp` バイナリとモデルのパスを解決する．
+
+    未設定または空白なら `ValueError` を送出する（fail fast）．
+    """
+    cli = env.get(ENV_WHISPER_CLI, "").strip()
+    if not cli:
+        raise ValueError(
+            f"環境変数 {ENV_WHISPER_CLI} が未設定です．whisper-cli の絶対パスを設定してください．"
+        )
+    model = env.get(ENV_WHISPER_MODEL, "").strip()
+    if not model:
+        raise ValueError(
+            f"環境変数 {ENV_WHISPER_MODEL} が未設定です．ggml モデルの絶対パスを設定してください．"
+        )
+    return Path(cli), Path(model)
+
+
+# ---------- orchestration ----------
+
+
+def transcribe(
+    *,
+    audio_path: Path,
+    vocabulary_path: Path,
+    output_dir: Path,
+    whisper_cli: Path,
+    whisper_model: Path,
+    language: str = DEFAULT_LANGUAGE,
+) -> Path:
+    """音声を WAV へ変換し `whisper.cpp` で文字起こしして txt パスを返す．"""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = audio_path.stem
+    wav_path = output_dir / f"{stem}.wav"
+    output_stem = output_dir / stem
+
+    # 辞書の読み込みは高コストな変換の前に行い，不正なら fail fast する．
+    prompt = load_prompt_words(vocabulary_path)
+
+    ffmpeg_cmd = build_ffmpeg_command(audio_path, wav_path)
+    if subprocess.run(ffmpeg_cmd).returncode != 0:
+        raise RuntimeError(f"ffmpeg による WAV 変換に失敗しました: {audio_path}")
+
+    whisper_cmd = build_whisper_command(
+        whisper_cli,
+        whisper_model,
+        wav_path,
+        output_stem,
+        prompt=prompt,
+        language=language,
+    )
+    if subprocess.run(whisper_cmd).returncode != 0:
+        raise RuntimeError(f"whisper.cpp による文字起こしに失敗しました: {audio_path}")
+
+    return output_dir / f"{stem}.txt"
+
+
+# ---------- CLI ----------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="録音音声を whisper.cpp で文字起こしし，生テキストを出力する"
+    )
+    parser.add_argument("--audio", type=Path, required=True, help="入力音声ファイルのパス")
+    parser.add_argument(
+        "--vocabulary",
+        type=Path,
+        required=True,
+        help="canonical 語を --prompt へ注入する vocabulary.yml のパス",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="生テキストと中間 WAV の出力先（無ければ作成する．Git 管理外を想定）",
+    )
+    parser.add_argument(
+        "--language",
+        default=DEFAULT_LANGUAGE,
+        help=f"文字起こし言語（既定: {DEFAULT_LANGUAGE}）",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=Path(".env"),
+        help="WHISPER_CLI_PATH／WHISPER_MODEL_PATH を読む .env のパス（既定: .env）",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.audio.exists() or not args.audio.is_file():
+        print(f"音声ファイルが見つかりません: {args.audio}", file=sys.stderr)
+        return 2
+    if not args.vocabulary.exists() or not args.vocabulary.is_file():
+        print(f"辞書ファイルが見つかりません: {args.vocabulary}", file=sys.stderr)
+        return 2
+
+    # os.environ を .env より優先する（publish.py と同じ規約）．
+    env_file_vars = load_env_file(args.env_file)
+    merged_env = {**env_file_vars, **os.environ}
+    try:
+        whisper_cli, whisper_model = resolve_whisper_paths(merged_env)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    for label, path in (("whisper-cli", whisper_cli), ("モデル", whisper_model)):
+        if not path.exists():
+            print(f"{label}が見つかりません: {path}", file=sys.stderr)
+            return 2
+
+    try:
+        written = transcribe(
+            audio_path=args.audio,
+            vocabulary_path=args.vocabulary,
+            output_dir=args.output_dir,
+            whisper_cli=whisper_cli,
+            whisper_model=whisper_model,
+            language=args.language,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(written)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/transcribe_audio.py
+++ b/scripts/transcribe_audio.py
@@ -56,7 +56,12 @@ def load_prompt_words(vocabulary_path: Path) -> str:
     if not vocabulary_path.exists():
         raise ValueError(f"辞書ファイルが見つかりません: {vocabulary_path}")
 
-    data = yaml.safe_load(vocabulary_path.read_text(encoding="utf-8"))
+    try:
+        data = yaml.safe_load(vocabulary_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"辞書ファイルの読み込みまたは解析に失敗しました: {vocabulary_path}: {exc}"
+        ) from exc
     if data is None:
         return ""
     if not isinstance(data, Mapping):
@@ -208,7 +213,13 @@ def transcribe(
     prompt = load_prompt_words(vocabulary_path)
 
     ffmpeg_cmd = build_ffmpeg_command(audio_path, wav_path)
-    if subprocess.run(ffmpeg_cmd).returncode != 0:
+    try:
+        ffmpeg_result = subprocess.run(ffmpeg_cmd)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "ffmpeg が見つかりません．PATH 上に ffmpeg が存在することを確認してください．"
+        ) from exc
+    if ffmpeg_result.returncode != 0:
         raise RuntimeError(f"ffmpeg による WAV 変換に失敗しました: {audio_path}")
 
     whisper_cmd = build_whisper_command(
@@ -287,7 +298,7 @@ def main(argv: list[str] | None = None) -> int:
             whisper_model=whisper_model,
             language=args.language,
         )
-    except (RuntimeError, ValueError) as exc:
+    except (RuntimeError, ValueError, OSError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/tests/test_transcribe_audio.py
+++ b/tests/test_transcribe_audio.py
@@ -1,0 +1,354 @@
+"""transcribe_audio.py のテスト．
+
+録音音声から生の文字起こしテキストを得る振る舞いを検証する．
+TDD の Red-Green-Refactor で実装する．実際の `ffmpeg`／`whisper.cpp`
+呼び出しは `subprocess.run` をモックして検証し，外部依存なしで回す．
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transcribe_audio import (
+    build_ffmpeg_command,
+    build_whisper_command,
+    load_env_file,
+    load_prompt_words,
+    main,
+    resolve_whisper_paths,
+    transcribe,
+)
+
+
+# ---------- load_prompt_words ----------
+
+
+def _write_vocabulary(path: Path) -> None:
+    path.write_text(
+        "version: 1\n"
+        "places:\n"
+        "  - canonical: 旭川\n"
+        "    aliases: [朝日川]\n"
+        "  - canonical: 函館\n"
+        "    aliases: [箱立て]\n"
+        "organizations:\n"
+        "  - canonical: PyCon JP\n"
+        "    aliases: [パイコンジャパン]\n"
+        "technical_terms:\n"
+        "  - canonical: GitHub\n"
+        "    aliases: [ギットハブ]\n",
+        encoding="utf-8",
+    )
+
+
+def test_load_prompt_words_collects_canonical_across_categories(tmp_path: Path) -> None:
+    vocab = tmp_path / "vocabulary.yml"
+    _write_vocabulary(vocab)
+    prompt = load_prompt_words(vocab)
+    # places / organizations / technical_terms の canonical を順に連結する
+    assert prompt == "旭川、函館、PyCon JP、GitHub"
+
+
+def test_load_prompt_words_returns_empty_for_no_entries(tmp_path: Path) -> None:
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    assert load_prompt_words(vocab) == ""
+
+
+def test_load_prompt_words_raises_when_file_missing(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="辞書ファイルが見つかりません"):
+        load_prompt_words(tmp_path / "absent.yml")
+
+
+def test_load_prompt_words_raises_when_not_mapping(tmp_path: Path) -> None:
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("- just\n- a list\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="マッピングである必要があります"):
+        load_prompt_words(vocab)
+
+
+def test_load_prompt_words_deduplicates_preserving_order(tmp_path: Path) -> None:
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text(
+        "places:\n"
+        "  - canonical: 旭川\n"
+        "organizations:\n"
+        "  - canonical: 旭川\n"
+        "  - canonical: PyCon JP\n",
+        encoding="utf-8",
+    )
+    assert load_prompt_words(vocab) == "旭川、PyCon JP"
+
+
+# ---------- build_ffmpeg_command ----------
+
+
+def test_build_ffmpeg_command_converts_to_16k_mono_wav() -> None:
+    cmd = build_ffmpeg_command(Path("in.m4a"), Path("out.wav"))
+    assert cmd[0] == "ffmpeg"
+    assert "-ar" in cmd and cmd[cmd.index("-ar") + 1] == "16000"
+    assert "-ac" in cmd and cmd[cmd.index("-ac") + 1] == "1"
+    # 入力と出力が末尾・指定位置に含まれる
+    assert "-i" in cmd and cmd[cmd.index("-i") + 1] == "in.m4a"
+    assert cmd[-1] == "out.wav"
+
+
+def test_build_ffmpeg_command_overwrites_without_prompting() -> None:
+    cmd = build_ffmpeg_command(Path("in.m4a"), Path("out.wav"))
+    # 既存 WAV があっても対話確認で停止しないよう -y を付ける
+    assert "-y" in cmd
+
+
+# ---------- build_whisper_command ----------
+
+
+def test_build_whisper_command_uses_standard_flags() -> None:
+    cmd = build_whisper_command(
+        Path("whisper-cli.exe"),
+        Path("ggml-large-v3.bin"),
+        Path("audio.wav"),
+        Path("/out/audio"),
+        prompt="旭川、函館",
+        language="ja",
+    )
+    assert cmd[0] == "whisper-cli.exe"
+    assert "-m" in cmd and cmd[cmd.index("-m") + 1] == "ggml-large-v3.bin"
+    assert "-f" in cmd and cmd[cmd.index("-f") + 1] == "audio.wav"
+    assert "-l" in cmd and cmd[cmd.index("-l") + 1] == "ja"
+    # ループ対策の -mc 0 を標準化する（STT パイロットの判定）
+    assert "-mc" in cmd and cmd[cmd.index("-mc") + 1] == "0"
+    # テキスト出力と出力先 stem
+    assert "-otxt" in cmd
+    assert "-of" in cmd and cmd[cmd.index("-of") + 1] == str(Path("/out/audio"))
+    # 辞書語を初期プロンプトへ注入する
+    assert "--prompt" in cmd and cmd[cmd.index("--prompt") + 1] == "旭川、函館"
+
+
+def test_build_whisper_command_omits_prompt_when_empty() -> None:
+    cmd = build_whisper_command(
+        Path("whisper-cli.exe"),
+        Path("model.bin"),
+        Path("audio.wav"),
+        Path("/out/audio"),
+        prompt="",
+        language="ja",
+    )
+    assert "--prompt" not in cmd
+
+
+# ---------- resolve_whisper_paths ----------
+
+
+def test_resolve_whisper_paths_reads_env() -> None:
+    env = {"WHISPER_CLI_PATH": "C:/w/whisper-cli.exe", "WHISPER_MODEL_PATH": "C:/w/m.bin"}
+    cli, model = resolve_whisper_paths(env)
+    assert cli == Path("C:/w/whisper-cli.exe")
+    assert model == Path("C:/w/m.bin")
+
+
+def test_resolve_whisper_paths_raises_when_cli_unset() -> None:
+    with pytest.raises(ValueError, match="WHISPER_CLI_PATH"):
+        resolve_whisper_paths({"WHISPER_MODEL_PATH": "C:/w/m.bin"})
+
+
+def test_resolve_whisper_paths_raises_when_model_unset() -> None:
+    with pytest.raises(ValueError, match="WHISPER_MODEL_PATH"):
+        resolve_whisper_paths({"WHISPER_CLI_PATH": "C:/w/whisper-cli.exe"})
+
+
+def test_resolve_whisper_paths_raises_when_blank() -> None:
+    with pytest.raises(ValueError, match="WHISPER_CLI_PATH"):
+        resolve_whisper_paths({"WHISPER_CLI_PATH": "   ", "WHISPER_MODEL_PATH": "m"})
+
+
+# ---------- load_env_file ----------
+
+
+def test_load_env_file_parses_keys(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        '# コメント行\n'
+        'export WHISPER_CLI_PATH="C:/w/whisper-cli.exe"\n'
+        "WHISPER_MODEL_PATH=C:/w/m.bin\n",
+        encoding="utf-8",
+    )
+    parsed = load_env_file(env)
+    assert parsed["WHISPER_CLI_PATH"] == "C:/w/whisper-cli.exe"
+    assert parsed["WHISPER_MODEL_PATH"] == "C:/w/m.bin"
+
+
+def test_load_env_file_returns_empty_when_missing(tmp_path: Path) -> None:
+    assert load_env_file(tmp_path / "absent.env") == {}
+
+
+def test_main_reads_paths_from_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "m.bin"
+    model.write_bytes(b"x")
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        f"WHISPER_CLI_PATH={cli}\nWHISPER_MODEL_PATH={model}\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("WHISPER_CLI_PATH", raising=False)
+    monkeypatch.delenv("WHISPER_MODEL_PATH", raising=False)
+
+    def fake_run(cmd, **kwargs):
+        if Path(str(cmd[0])).name.startswith("whisper"):
+            of_index = cmd.index("-of")
+            Path(str(cmd[of_index + 1]) + ".txt").write_text("本文", encoding="utf-8")
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr("transcribe_audio.subprocess.run", fake_run)
+
+    code = main(
+        [
+            "--audio",
+            str(audio),
+            "--vocabulary",
+            str(vocab),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--env-file",
+            str(env_file),
+        ]
+    )
+    assert code == 0
+
+
+# ---------- transcribe (orchestration) ----------
+
+
+def test_transcribe_runs_ffmpeg_then_whisper_and_returns_txt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio = tmp_path / "2026-04-30-旭川.m4a"
+    audio.write_bytes(b"fake-audio")
+    vocab = tmp_path / "vocabulary.yml"
+    _write_vocabulary(vocab)
+    out_dir = tmp_path / "scratch"
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "ggml-large-v3.bin"
+    model.write_bytes(b"x")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append([str(c) for c in cmd])
+        # whisper 実行を模して，期待される txt を生成する
+        if Path(str(cmd[0])).name.startswith("whisper"):
+            of_index = cmd.index("-of")
+            Path(str(cmd[of_index + 1]) + ".txt").write_text("文字起こし本文", encoding="utf-8")
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr("transcribe_audio.subprocess.run", fake_run)
+
+    result = transcribe(
+        audio_path=audio,
+        vocabulary_path=vocab,
+        output_dir=out_dir,
+        whisper_cli=cli,
+        whisper_model=model,
+        language="ja",
+    )
+
+    assert result == out_dir / "2026-04-30-旭川.txt"
+    assert result.read_text(encoding="utf-8") == "文字起こし本文"
+    # ffmpeg → whisper の順に 2 回呼ばれる
+    assert len(calls) == 2
+    assert calls[0][0] == "ffmpeg"
+    assert Path(calls[1][0]).name == "whisper-cli.exe"
+    # 中間 WAV は出力ディレクトリ配下に作られる
+    wav_arg = calls[0][-1]
+    assert wav_arg == str(out_dir / "2026-04-30-旭川.wav")
+
+
+def test_transcribe_raises_when_ffmpeg_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "m.bin"
+    model.write_bytes(b"x")
+
+    def fake_run(cmd, **kwargs):
+        class _Result:
+            returncode = 1
+
+        return _Result()
+
+    monkeypatch.setattr("transcribe_audio.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="ffmpeg"):
+        transcribe(
+            audio_path=audio,
+            vocabulary_path=vocab,
+            output_dir=tmp_path / "out",
+            whisper_cli=cli,
+            whisper_model=model,
+            language="ja",
+        )
+
+
+# ---------- main (CLI) ----------
+
+
+def test_main_returns_2_when_audio_missing(tmp_path: Path) -> None:
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    code = main(
+        [
+            "--audio",
+            str(tmp_path / "absent.m4a"),
+            "--vocabulary",
+            str(vocab),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+    assert code == 2
+
+
+def test_main_returns_2_when_env_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    monkeypatch.delenv("WHISPER_CLI_PATH", raising=False)
+    monkeypatch.delenv("WHISPER_MODEL_PATH", raising=False)
+    code = main(
+        [
+            "--audio",
+            str(audio),
+            "--vocabulary",
+            str(vocab),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--env-file",
+            str(tmp_path / "absent.env"),
+        ]
+    )
+    assert code == 2

--- a/tests/test_transcribe_audio.py
+++ b/tests/test_transcribe_audio.py
@@ -69,6 +69,14 @@ def test_load_prompt_words_raises_when_not_mapping(tmp_path: Path) -> None:
         load_prompt_words(vocab)
 
 
+def test_load_prompt_words_raises_on_malformed_yaml(tmp_path: Path) -> None:
+    # YAML 解析失敗を無言クラッシュさせず，パスを含む ValueError へ変換する
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("places: [unterminated\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="読み込みまたは解析に失敗"):
+        load_prompt_words(vocab)
+
+
 def test_load_prompt_words_deduplicates_preserving_order(tmp_path: Path) -> None:
     vocab = tmp_path / "vocabulary.yml"
     vocab.write_text(
@@ -309,6 +317,73 @@ def test_transcribe_raises_when_ffmpeg_fails(
             whisper_model=model,
             language="ja",
         )
+
+
+def test_transcribe_raises_friendly_error_when_ffmpeg_not_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ffmpeg 未インストール（PATH 上に無い）時の FileNotFoundError を
+    # 分かりやすい RuntimeError へ変換する
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "m.bin"
+    model.write_bytes(b"x")
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr("transcribe_audio.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="ffmpeg が見つかりません"):
+        transcribe(
+            audio_path=audio,
+            vocabulary_path=vocab,
+            output_dir=tmp_path / "out",
+            whisper_cli=cli,
+            whisper_model=model,
+            language="ja",
+        )
+
+
+def test_main_returns_1_when_transcribe_raises_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # I/O 由来の OSError でもスタックトレースを出さずに終了コード 1 を返す
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "m.bin"
+    model.write_bytes(b"x")
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        f"WHISPER_CLI_PATH={cli}\nWHISPER_MODEL_PATH={model}\n", encoding="utf-8"
+    )
+
+    def boom(**kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("transcribe_audio.transcribe", boom)
+
+    code = main(
+        [
+            "--audio",
+            str(audio),
+            "--vocabulary",
+            str(vocab),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--env-file",
+            str(env_file),
+        ]
+    )
+    assert code == 1
 
 
 # ---------- main (CLI) ----------

--- a/tests/test_transcribe_audio.py
+++ b/tests/test_transcribe_audio.py
@@ -109,6 +109,12 @@ def test_build_ffmpeg_command_overwrites_without_prompting() -> None:
     assert "-y" in cmd
 
 
+def test_build_ffmpeg_command_suppresses_banner_noise() -> None:
+    cmd = build_ffmpeg_command(Path("in.m4a"), Path("out.wav"))
+    # コンソールを埋めるバナー出力を抑え，エラー時のみログを出す
+    assert "-loglevel" in cmd and cmd[cmd.index("-loglevel") + 1] == "error"
+
+
 # ---------- build_whisper_command ----------
 
 
@@ -130,6 +136,8 @@ def test_build_whisper_command_uses_standard_flags() -> None:
     # テキスト出力と出力先 stem
     assert "-otxt" in cmd
     assert "-of" in cmd and cmd[cmd.index("-of") + 1] == str(Path("/out/audio"))
+    # 結果以外のコンソール出力を抑制する（whisper-cli に --quiet は無いため -np）
+    assert "-np" in cmd
     # 辞書語を初期プロンプトへ注入する
     assert "--prompt" in cmd and cmd[cmd.index("--prompt") + 1] == "旭川、函館"
 
@@ -349,6 +357,68 @@ def test_transcribe_raises_friendly_error_when_ffmpeg_not_installed(
         )
 
 
+def test_transcribe_raises_friendly_error_when_whisper_not_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # whisper-cli が見つからない場合の FileNotFoundError も
+    # 分かりやすい RuntimeError へ変換する（ffmpeg と対称）
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    cli = tmp_path / "whisper-cli.exe"
+    cli.write_bytes(b"x")
+    model = tmp_path / "m.bin"
+    model.write_bytes(b"x")
+
+    def fake_run(cmd, **kwargs):
+        if "ffmpeg" in str(cmd[0]):
+            class _Result:
+                returncode = 0
+
+            return _Result()
+        raise FileNotFoundError("whisper-cli")
+
+    monkeypatch.setattr("transcribe_audio.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="whisper-cli が見つかりません"):
+        transcribe(
+            audio_path=audio,
+            vocabulary_path=vocab,
+            output_dir=tmp_path / "out",
+            whisper_cli=cli,
+            whisper_model=model,
+            language="ja",
+        )
+
+
+def test_main_returns_2_when_explicit_env_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 明示指定した --env-file が存在しない場合は，黙って os.environ に
+    # フォールバックせず，ファイル不在を明示エラーで知らせる
+    audio = tmp_path / "a.m4a"
+    audio.write_bytes(b"x")
+    vocab = tmp_path / "vocabulary.yml"
+    vocab.write_text("version: 1\n", encoding="utf-8")
+    monkeypatch.setenv("WHISPER_CLI_PATH", str(tmp_path / "whisper-cli.exe"))
+    monkeypatch.setenv("WHISPER_MODEL_PATH", str(tmp_path / "m.bin"))
+
+    code = main(
+        [
+            "--audio",
+            str(audio),
+            "--vocabulary",
+            str(vocab),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--env-file",
+            str(tmp_path / "typo.env"),
+        ]
+    )
+    assert code == 2
+
+
 def test_main_returns_1_when_transcribe_raises_oserror(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -414,6 +484,8 @@ def test_main_returns_2_when_env_unset(
     vocab.write_text("version: 1\n", encoding="utf-8")
     monkeypatch.delenv("WHISPER_CLI_PATH", raising=False)
     monkeypatch.delenv("WHISPER_MODEL_PATH", raising=False)
+    # 既定の .env（不在は許容）のまま，環境変数が未設定の経路を試す
+    monkeypatch.chdir(tmp_path)
     code = main(
         [
             "--audio",
@@ -422,8 +494,6 @@ def test_main_returns_2_when_env_unset(
             str(vocab),
             "--output-dir",
             str(tmp_path / "out"),
-            "--env-file",
-            str(tmp_path / "absent.env"),
         ]
     )
     assert code == 2


### PR DESCRIPTION
フェーズ 7 タスク 1．録音音声を `ffmpeg` で 16kHz モノラル WAV へ変換し，`whisper.cpp`（`large-v3`）で文字起こしする CLI を TDD で新設する．これでフェーズ 7 の実装タスク 4 件がすべて完了する．

## 変更内容

- `scripts/transcribe_audio.py` を新設．
  - バイナリ／モデルパスは `WHISPER_CLI_PATH`／`WHISPER_MODEL_PATH` または `--env-file` の `.env` から解決（`os.environ` 優先．`publish.py` と同規約）．未設定なら明示エラーで停止する．
  - ループ対策として `-mc 0` を標準化（STT パイロットの判定）．
  - `vocabulary.yml` の canonical 語を `--prompt` へ注入し固有名詞の正答を補助する．
  - 中間 WAV・生テキストは再生成可能なため `.scratch/` 等へ出力する．
- `README` に使い方を追記．
- テスト 20 件を追加（全 233 件 pass）．

## 実機検証

実音声 8 分を RTX 4070 Ti で約 35 秒で処理し，タイムスタンプ無しのクリーンなテキスト出力を確認した．「旭川」が「朝日川」と誤認識される事象は初期プロンプトが soft hint であることに起因し，残る誤りは下流の `transcript-corrector` で補正する前提とした（辞書エイリアス登録は別タスク）．

🤖 Generated with [Claude Code](https://claude.com/claude-code)