### PR TITLE
fix(list_materials): インライン配列のクォート内カンマで要素を誤分割しない

### DIFF
--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -68,9 +68,9 @@ def _split_inline_array(inner: str) -> list[str]:
     """
     elements: list[str] = []
     current: list[str] = []
-    in_double = False
-    in_single = False
-    escaped = False
+    in_double: bool = False
+    in_single: bool = False
+    escaped: bool = False
     for ch in inner:
         if escaped:
             current.append(ch)

--- a/scripts/list_materials.py
+++ b/scripts/list_materials.py
@@ -57,6 +57,49 @@ def _dequote_list_element(item_val: str) -> str:
     return item_val
 
 
+def _split_inline_array(inner: str) -> list[str]:
+    """インライン配列の中身をクォート状態を考慮して要素分割する．
+
+    クォート外のカンマだけを要素境界とする．ダブルクォート内は ``\\`` を
+    直後 1 文字のエスケープとして扱い ``\\"`` で閉じない．シングルクォート内は
+    エスケープ処理せず次の ``'`` までを 1 要素とみなす．クォートの除去と
+    エスケープ解釈は後段の :func:`_dequote_list_element` に委ねるため，
+    各要素はクォート文字を含んだまま返す．
+    """
+    elements: list[str] = []
+    current: list[str] = []
+    in_double = False
+    in_single = False
+    escaped = False
+    for ch in inner:
+        if escaped:
+            current.append(ch)
+            escaped = False
+        elif in_double:
+            current.append(ch)
+            if ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_double = False
+        elif in_single:
+            current.append(ch)
+            if ch == "'":
+                in_single = False
+        elif ch == '"':
+            current.append(ch)
+            in_double = True
+        elif ch == "'":
+            current.append(ch)
+            in_single = True
+        elif ch == ",":
+            elements.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    elements.append("".join(current))
+    return elements
+
+
 def _parse_simple_yaml(text: str) -> dict[str, Any]:
     """ネスト無し・コメント無視の限定 YAML パーサ．
 
@@ -107,7 +150,7 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
             # インライン配列表記: ["tagA", "tagB"] または [a, b]
             inner = raw_val.strip("[]")
             items_inline: list[str] = []
-            for item_raw in inner.split(","):
+            for item_raw in _split_inline_array(inner):
                 item_raw = item_raw.strip()
                 if not item_raw:
                     continue

--- a/tests/test_list_materials.py
+++ b/tests/test_list_materials.py
@@ -593,3 +593,62 @@ def test_block_list_element_with_trailing_data_is_not_truncated() -> None:
     assert result["auto_tags"] == ['"foo"bar'], (
         f"閉じクォート後の余分なデータが切り捨てられた: {result['auto_tags']!r}"
     )
+
+
+# ---------- Issue #36: インライン配列のクォート内カンマ ----------
+
+
+def test_inline_array_double_quoted_element_with_comma_not_split() -> None:
+    """ダブルクォート内のカンマを要素境界として誤分割しない（Issue #36）．
+    tags: ["a,b", "c"] → ['a,b', 'c'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'tags: ["a,b", "c"]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ["a,b", "c"], (
+        f"ダブルクォート内のカンマで誤分割された: {result['tags']!r}"
+    )
+
+
+def test_inline_array_single_quoted_element_with_comma_not_split() -> None:
+    """シングルクォート内のカンマを要素境界として誤分割しない（Issue #36）．
+    tags: ['a,b'] → ['a,b'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = "tags: ['a,b']"
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ["a,b"], (
+        f"シングルクォート内のカンマで誤分割された: {result['tags']!r}"
+    )
+
+
+def test_inline_array_escaped_quote_then_comma_splits_correctly() -> None:
+    """エスケープ済みクォートを閉じと誤認せず，後続のクォート外カンマで分割する（Issue #36）．
+    tags: ["a\\"b", "c,d"] → ['a"b', 'c,d'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = 'tags: ["a\\"b", "c,d"]'
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ['a"b', "c,d"], (
+        f"エスケープ済みクォートとクォート内カンマの解析に失敗した: {result['tags']!r}"
+    )
+
+
+def test_inline_array_unquoted_elements_still_split_on_comma() -> None:
+    """クォートなし要素は従来どおりカンマで分割される（Issue #36 の回帰防止）．
+    tags: [a, b, c] → ['a', 'b', 'c'] になる．
+    """
+    from list_materials import _parse_simple_yaml
+
+    yaml_text = "tags: [a, b, c]"
+    result = _parse_simple_yaml(yaml_text)
+
+    assert result["tags"] == ["a", "b", "c"], (
+        f"クォートなし要素の分割が壊れた: {result['tags']!r}"
+    )


### PR DESCRIPTION
## 概要

`_parse_simple_yaml` のインライン配列パスは `inner.split(",")` で要素を分割していたため，`["a,b", "c"]` のようにクォート内へカンマを含む要素を境界で誤分割していた（`Closes #36`）．

クォート状態（ダブル／シングル）と `\"` エスケープを追跡する `_split_inline_array` を導入し，クォート外のカンマだけで分割するよう修正する．クォート除去とエスケープ解釈は従来どおり `_dequote_list_element` に委ねる．

## 変更点

- `scripts/list_materials.py`：`_split_inline_array` を新設し，インライン配列の分割に使用．
- `tests/test_list_materials.py`：テスト 4 件追加（ダブル／シングルのクォート内カンマ，エスケープ＋カンマ，クォートなし要素の回帰防止）．

## テスト

- TDD で Red→Green を確認．
- `list_materials` 系 35 件，標準ライブラリのみのテスト 170 件 pass．
- `yaml` 依存の 3 ファイルは `.venv` への dev 依存未導入により collection エラー（本変更とは無関係の環境要因）．

🤖 Generated with [Claude Code](https://claude.com/claude-code)