### PR TITLE
docs: 実装フェーズ表にフェーズ 6/7 を反映する

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,7 +146,7 @@ Skill はオーケストレーション役，Subagent は個別タスクの実�
 
 ## 🛤️ 段階的実装フェーズ
 
-実装は 0 から 5 までの 6 フェーズで進める．本リポジトリで提供する成果物の範囲を以下に示す．
+実装は 0 から 7 までの 8 フェーズで進める．本リポジトリで提供する成果物の範囲を以下に示す．
 
 | フェーズ | 提供する成果物 | 状態 |
 |---|---|---|
@@ -156,6 +156,8 @@ Skill はオーケストレーション役，Subagent は個別タスクの実�
 | 3 | `agent-templates/article-proposer.md`，`agent-templates/article-drafter.md`，`skill-templates/structure-note/`，`skill-templates/writing-style/` のひな形 | 完了 |
 | 4 | `.textlintrc.json`，`prh.yml`，`.markdownlint-cli2.yaml` の汎用設定，`agent-templates/draft-reviewer.md`，`skill-templates/review-draft/`，`publish.py` | 完了 |
 | 5 | `build_dictionary.py`，月次運用のドキュメント，CI・Skill チューニング | 完了 |
+| 6 | `parse_enex.py` の 2 セクション化（`<h1>` 非依存），`scripts/prompt-maker/` の非推奨化，STT パイロットによる `whisper.cpp` 採用判断 | 完了 |
+| 7 | `transcribe_audio.py`，`build_material.py`，`parse_enex.py` の非推奨化（Evernote 廃止・音声直接取り込み経路） | 完了 |
 
 各フェーズは GitHub Issue（`phase-N` ラベル）で管理する．フェーズ間で依存があれば Issue 本文に明記する．
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 | 4 | lint 設定ファイル群，`draft-reviewer`，`review-draft`，`publish.py` | 完了 |
 | 5 | `build_dictionary.py`，月次運用ドキュメント，CI・Skill チューニング | 完了 |
 | 6 | `parse_enex.py` の 2 セクション化，`prompt-maker/` の非推奨化（Evernote AI 連携廃止），STT パイロット | 完了 |
-| 7 | `transcribe_audio.py`，`build_material.py`，`parse_enex.py` の非推奨化（音声直接取り込み経路） | 完了 |
+| 7 | `transcribe_audio.py`，`build_material.py`，`parse_enex.py` の非推奨化（Evernote 廃止・音声直接取り込み経路） | 完了 |
 
 `.textlintrc.json`・`prh.yml`・`.markdownlint-cli2.yaml` はフェーズ 4 で追加する．それまでは中央テンプレート（[tomio2480/github-workflows](https://github.com/tomio2480/github-workflows)）の標準設定が CI で適用される．
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ## 🛤️ 実装フェーズと現状
 
-実装は 0 から 5 までの 6 フェーズで進める．フェーズ 0〜3 はクローズ済みである．各フェーズの進捗は GitHub Issue（`phase-N` ラベル）で追跡する．
+実装は 0 から 7 までの 8 フェーズで進める．全フェーズがクローズ済みである．各フェーズの進捗は GitHub Issue（`phase-N` ラベル）で追跡する．
 
 表 2 フェーズと主な成果物．
 
@@ -78,6 +78,8 @@
 | 3 | `article-proposer`，`article-drafter`，`structure-note`，`writing-style` ひな形 | 完了 |
 | 4 | lint 設定ファイル群，`draft-reviewer`，`review-draft`，`publish.py` | 完了 |
 | 5 | `build_dictionary.py`，月次運用ドキュメント，CI・Skill チューニング | 完了 |
+| 6 | `parse_enex.py` の 2 セクション化，`prompt-maker/` の非推奨化（Evernote AI 連携廃止），STT パイロット | 完了 |
+| 7 | `transcribe_audio.py`，`build_material.py`，`parse_enex.py` の非推奨化（音声直接取り込み経路） | 完了 |
 
 `.textlintrc.json`・`prh.yml`・`.markdownlint-cli2.yaml` はフェーズ 4 で追加する．それまでは中央テンプレート（[tomio2480/github-workflows](https://github.com/tomio2480/github-workflows)）の標準設定が CI で適用される．
 


### PR DESCRIPTION
## 概要

`README.md` と `ARCHITECTURE.md` の実装フェーズ表が 0〜5 で止まっており，フェーズ 6（Evernote AI 廃止の反映・STT パイロット）とフェーズ 7（Evernote 廃止・音声直接取り込み経路）が未反映だった．本文では `transcribe_audio.py`・`build_material.py` を既に説明済みで齟齬が生じていた．

設計のフェーズ定義に揃えて表へ 2 行追記し，導入文の総フェーズ数（6→8）も更新する．

## 変更点

- `README.md`：実装フェーズ表にフェーズ 6・7 を追記．導入文を「0 から 7 までの 8 フェーズ」「全フェーズがクローズ済み」へ更新．
- `ARCHITECTURE.md`：段階的実装フェーズ表にフェーズ 6・7 を追記．導入文の総フェーズ数を更新．

## 補足

ドキュメントのみの変更でコード・テストへの影響なし．

🤖 Generated with [Claude Code](https://claude.com/claude-code)