### PR TITLE
feat(publish): 既存下書きの更新 PUT と ID 回収 sync に対応する

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ blog-pipeline/
 │  ├─ build_material.py       人間メモ + 生文字起こし → 2 セクション素材（フェーズ 7）
 │  ├─ list_materials.py       素材一覧の取得
 │  ├─ build_dictionary.py     形態素解析で固有名詞辞書を更新
-│  ├─ publish.py              AtomPub 投稿（常に下書き）
+│  ├─ publish.py              AtomPub 投稿・更新（常に下書き）
 │  └─ prompt-maker/
 │     ├─ generate_prompts.py  Evernote AI プロンプト生成（非推奨，2026-06-12 廃止）
 │     ├─ test_generate_prompts.py

--- a/README.md
+++ b/README.md
@@ -221,7 +221,19 @@ python scripts/publish.py drafts/2026-05-07-my-article.md
 python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.env
 ```
 
-常に下書きとして投稿する．公開判断ははてなブログ管理画面で人間が行う．
+常に下書きとして投稿する（`<app:draft>yes</app:draft>` をハードコード）．公開判断ははてなブログ管理画面で人間が行う．
+
+複数ファイルをまとめて送れる．送信メソッドは frontmatter で自動判定する．
+
+- `hatena_entry_id` なし：新規 `POST`．成功時にレスポンスの entry ID を frontmatter へ書き戻す．
+- `hatena_entry_id` あり：既存下書きの更新 `PUT`．未公開の下書きを再送する用途．
+- `hatena_published: true`：公開後ははてな側を真とするため，自動送信を拒否する（安全ガード）．
+
+`--sync` は送信せず，はてな側のエントリ一覧を取得して title 一致で `hatena_entry_id` を frontmatter へ記録する．送信済みだが ID 未記録の下書きを更新可能にするための回収に使う．
+
+```bash
+python scripts/publish.py drafts/*.md --sync
+```
 
 ### テスト
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -1,10 +1,14 @@
-"""はてなブログ AtomPub API を使って Markdown ドラフトを下書き投稿する CLI スクリプト．
+"""はてなブログ AtomPub API を使って Markdown ドラフトを下書き投稿・更新する CLI スクリプト．
 
 設計方針:
 
 - 標準ライブラリのみで実装する．サードパーティ依存ゼロ．
 - `<app:draft>yes</app:draft>` をハードコードし，公開フラグは持たせない．
   公開判断ははてなブログの管理画面で人間が行う．
+- 送信メソッドは frontmatter で自動判定する．
+  `hatena_entry_id` なし → 新規 POST（成功時に entry ID を frontmatter へ書き戻す）．
+  `hatena_entry_id` あり → 既存下書きの更新 PUT．
+  `hatena_published: true` → 公開後ははてな側を真とするため自動送信を拒否する．
 - 環境変数（HATENA_USERNAME / HATENA_BLOG_ID / HATENA_API_KEY）は
   `--env-file`（既定: `.env`）から読み込む．
   環境変数に既に設定済みの場合はそちらを優先する（os.environ 優先）．
@@ -14,10 +18,11 @@
 
     python scripts/publish.py drafts/2026-05-07-my-article.md
     python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.env
+    python scripts/publish.py drafts/*.md --sync   # ID 回収のみ（送信しない）
 
 出力:
 
-    下書きが作成された場合，管理画面の URL を標準出力に書き出す．
+    下書きの作成・更新時，管理画面の URL を標準出力に書き出す．
     エラーは標準エラー出力に書き出し，exit code 1 で終了する．
 """
 
@@ -32,18 +37,33 @@ import re
 import sys
 import urllib.error
 import urllib.request
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
-
-# AtomPub エンドポイント（{username} と {blog_id} はランタイムで置換）
-ATOM_PUB_ENDPOINT = "https://blog.hatena.ne.jp/{username}/{blog_id}/atom/entry"
 
 # YAML フロントマターのデリミタ
 FRONTMATTER_DELIMITER = "---"
 
 # 管理画面の下書き URL ベース
 HATENA_BLOG_ADMIN_BASE = "https://blog.hatena.ne.jp/{username}/{blog_id}/edit?entry="
+
+# Atom / AtomPub の名前空間
+ATOM_NS = "http://www.w3.org/2005/Atom"
+APP_NS = "http://www.w3.org/2007/app"
+
+# hatena_published が真とみなす値
+_TRUTHY = {"true", "yes", "1", "on"}
+
+
+def build_collection_url(username: str, blog_id: str) -> str:
+    """コレクション URI（新規 POST 先・一覧取得先）を組み立てる．"""
+    return f"https://blog.hatena.ne.jp/{username}/{blog_id}/atom/entry"
+
+
+def build_member_url(username: str, blog_id: str, entry_id: str) -> str:
+    """メンバー URI（既存エントリの更新 PUT 先）を組み立てる．"""
+    return f"https://blog.hatena.ne.jp/{username}/{blog_id}/atom/entry/{entry_id}"
 
 
 def load_env_file(path: Path) -> dict[str, str]:
@@ -185,13 +205,118 @@ def extract_entry_id(response_body: bytes) -> str:
     return ""
 
 
-def post_draft(
+def decide_publish_method(fm: dict[str, str]) -> tuple[str, str | None]:
+    """フロントマターから送信メソッドを判定する．
+
+    - `hatena_published` が真 → 公開後ははてな側を真とするため自動送信を拒否（例外）．
+    - `hatena_entry_id` あり → ("PUT", entry_id)（既存下書きの更新）．
+    - それ以外 → ("POST", None)（新規作成）．
+    """
+    published = str(fm.get("hatena_published", "")).strip().lower() in _TRUTHY
+    if published:
+        raise ValueError(
+            "hatena_published が真のため自動送信を拒否します．"
+            "公開後ははてなブログ側を真とし，publish.py からの更新は行いません．"
+        )
+    entry_id = fm.get("hatena_entry_id") or None
+    if entry_id:
+        return ("PUT", entry_id)
+    return ("POST", None)
+
+
+def parse_collection_feed(xml_bytes: bytes) -> list[dict]:
+    """AtomPub コレクションフィードを解析し，エントリ一覧を返す．
+
+    各要素は `{"entry_id": str, "title": str, "draft": bool}`．
+    `entry_id` は `<id>` 末尾のハイフン直後の数字列．
+
+    入力は認証済みはてな AtomPub API（HTTPS）のレスポンスに限るため，
+    信頼境界の内側として扱う．`publish.py` は標準ライブラリのみ・
+    サードパーティ依存ゼロを設計原則とするため `defusedxml` は導入しない．
+    expat は外部エンティティ・外部 DTD を解決しないため XXE は対象外である．
+    """
+    root = ET.fromstring(xml_bytes)
+    results: list[dict] = []
+    for entry in root.findall(f"{{{ATOM_NS}}}entry"):
+        id_el = entry.find(f"{{{ATOM_NS}}}id")
+        title_el = entry.find(f"{{{ATOM_NS}}}title")
+        draft_el = entry.find(f"{{{APP_NS}}}control/{{{APP_NS}}}draft")
+        id_text = id_el.text if id_el is not None and id_el.text else ""
+        match = re.search(r"-(\d+)$", id_text)
+        entry_id = match.group(1) if match else ""
+        title = title_el.text if title_el is not None and title_el.text else ""
+        draft = (
+            draft_el is not None
+            and (draft_el.text or "").strip().lower() == "yes"
+        )
+        results.append({"entry_id": entry_id, "title": title, "draft": draft})
+    return results
+
+
+def parse_feed_next_link(xml_bytes: bytes) -> str | None:
+    """フィードの `<link rel="next" href="...">` を返す（なければ None）．"""
+    root = ET.fromstring(xml_bytes)
+    for link in root.findall(f"{{{ATOM_NS}}}link"):
+        if link.get("rel") == "next":
+            return link.get("href")
+    return None
+
+
+def upsert_frontmatter_field(text: str, key: str, value: str) -> str:
+    """フロントマターへ `key: value` を追記または置換する（本文は保つ）．"""
+    lines = text.splitlines(keepends=True)
+    new_line = f"{key}: {value}\n"
+    if not lines or lines[0].rstrip() != FRONTMATTER_DELIMITER:
+        return f"---\n{new_line}---\n\n{text}"
+
+    close = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == FRONTMATTER_DELIMITER:
+            close = i
+            break
+    if close is None:
+        return text
+
+    for j in range(1, close):
+        line = lines[j]
+        if ":" in line and not line.startswith((" ", "-")):
+            existing_key = line.partition(":")[0].strip()
+            if existing_key == key:
+                lines[j] = new_line
+                return "".join(lines)
+
+    lines.insert(close, new_line)
+    return "".join(lines)
+
+
+def _send_entry(
+    url: str,
+    entry_xml: bytes,
+    username: str,
+    api_key: str,
+    method: str,
+) -> bytes:
+    """AtomPub へエントリ XML を送信する（POST / PUT 共通）．"""
+    req = urllib.request.Request(
+        url,
+        data=entry_xml,
+        headers={
+            "Content-Type": "application/atom+xml; charset=utf-8",
+            "X-WSSE": build_wsse_header(username, api_key),
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+def publish_draft(
     draft_path: Path,
     username: str,
     blog_id: str,
     api_key: str,
 ) -> None:
-    """ドラフトファイルを読み込み，AtomPub 経由で下書き投稿する．"""
+    """ドラフトを読み込み，frontmatter に応じて新規 POST か更新 PUT で送る．"""
     text = draft_path.read_text(encoding="utf-8")
     fm, body = parse_frontmatter(text, source=str(draft_path))
 
@@ -199,34 +324,20 @@ def post_draft(
     if not title:
         title = draft_path.stem
 
-    entry_xml = build_atom_entry(title, body)
-    endpoint = ATOM_PUB_ENDPOINT.format(username=username, blog_id=blog_id)
-    wsse = build_wsse_header(username, api_key)
+    try:
+        method, entry_id = decide_publish_method(fm)
+    except ValueError as exc:
+        print(f"Skip: {draft_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    req = urllib.request.Request(
-        endpoint,
-        data=entry_xml,
-        headers={
-            "Content-Type": "application/atom+xml; charset=utf-8",
-            "X-WSSE": wsse,
-        },
-        method="POST",
-    )
+    entry_xml = build_atom_entry(title, body)
+    if method == "PUT":
+        url = build_member_url(username, blog_id, entry_id)  # type: ignore[arg-type]
+    else:
+        url = build_collection_url(username, blog_id)
 
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            response_body = resp.read()
-            entry_id = extract_entry_id(response_body)
-            if entry_id:
-                admin_url = (
-                    HATENA_BLOG_ADMIN_BASE.format(
-                        username=username, blog_id=blog_id
-                    )
-                    + entry_id
-                )
-                print(f"下書き投稿完了: {admin_url}")
-            else:
-                print("下書き投稿完了（URL の取得に失敗しました）")
+        response_body = _send_entry(url, entry_xml, username, api_key, method)
     except urllib.error.HTTPError as exc:
         body_text = exc.read().decode("utf-8", errors="replace")
         print(
@@ -238,15 +349,108 @@ def post_draft(
         print(f"Error: {exc.reason}", file=sys.stderr)
         sys.exit(1)
 
+    if method == "POST":
+        new_id = extract_entry_id(response_body)
+        if new_id:
+            updated = upsert_frontmatter_field(text, "hatena_entry_id", new_id)
+            draft_path.write_text(updated, encoding="utf-8")
+        entry_id = new_id
+
+    if entry_id:
+        admin_url = (
+            HATENA_BLOG_ADMIN_BASE.format(username=username, blog_id=blog_id)
+            + entry_id
+        )
+        verb = "更新" if method == "PUT" else "下書き投稿"
+        print(f"{verb}完了: {admin_url}")
+    else:
+        print("送信完了（entry ID の取得に失敗しました）")
+
+
+def fetch_all_entries(
+    username: str,
+    blog_id: str,
+    api_key: str,
+    *,
+    max_pages: int = 20,
+) -> list[dict]:
+    """コレクションフィードを rel=next で辿り，全エントリ一覧を返す．"""
+    url: str | None = build_collection_url(username, blog_id)
+    entries: list[dict] = []
+    pages = 0
+    while url and pages < max_pages:
+        req = urllib.request.Request(
+            url,
+            headers={"X-WSSE": build_wsse_header(username, api_key)},
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            xml_bytes = resp.read()
+        entries.extend(parse_collection_feed(xml_bytes))
+        url = parse_feed_next_link(xml_bytes)
+        pages += 1
+    return entries
+
+
+def sync_entry_ids(
+    draft_paths: list[Path],
+    username: str,
+    blog_id: str,
+    api_key: str,
+) -> None:
+    """はてな側の一覧と突合し，title 一致で hatena_entry_id を frontmatter へ書く．"""
+    try:
+        entries = fetch_all_entries(username, blog_id, api_key)
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8", errors="replace")
+        print(f"Error: HTTP {exc.code} {exc.reason}\n{body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as exc:
+        print(f"Error: {exc.reason}", file=sys.stderr)
+        sys.exit(1)
+
+    by_title: dict[str, str] = {}
+    for entry in entries:
+        # 同名が複数あれば最初の 1 件を採用する（重複は警告）．
+        title = entry["title"]
+        if title in by_title and by_title[title] != entry["entry_id"]:
+            print(f"Warning: 同名タイトルが複数あります: {title}", file=sys.stderr)
+            continue
+        by_title.setdefault(title, entry["entry_id"])
+
+    for path in draft_paths:
+        text = path.read_text(encoding="utf-8")
+        fm, _ = parse_frontmatter(text, source=str(path))
+        if fm.get("hatena_entry_id"):
+            print(f"Skip（ID 設定済み）: {path}")
+            continue
+        title = fm.get("draft_of") or path.stem
+        entry_id = by_title.get(title)
+        if not entry_id:
+            print(f"未一致（はてな側に該当なし）: {path}", file=sys.stderr)
+            continue
+        updated = upsert_frontmatter_field(text, "hatena_entry_id", entry_id)
+        path.write_text(updated, encoding="utf-8")
+        print(f"ID 記録: {path} -> {entry_id}")
+
+
+def _load_credentials(env_file: Path) -> tuple[str, str, str]:
+    env_vars = load_env_file(env_file)
+    username = get_env("HATENA_USERNAME", env_vars)
+    blog_id = get_env("HATENA_BLOG_ID", env_vars)
+    api_key = get_env("HATENA_API_KEY", env_vars)
+    return username, blog_id, api_key
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Markdown ドラフトをはてなブログに下書き投稿する",
+        description="Markdown ドラフトをはてなブログに下書き投稿・更新する",
     )
     parser.add_argument(
         "draft_file",
         type=Path,
-        help="投稿する Markdown ドラフトファイルのパス",
+        nargs="+",
+        help="対象の Markdown ドラフトファイル（複数可）",
     )
     parser.add_argument(
         "--env-file",
@@ -254,18 +458,27 @@ def main() -> None:
         default=Path(".env"),
         help="環境変数ファイルのパス（既定: .env）",
     )
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="送信せず，はてな側の一覧と title 照合で hatena_entry_id を frontmatter へ記録する",
+    )
     args = parser.parse_args()
 
-    if not args.draft_file.exists():
-        print(f"Error: ファイルが見つかりません: {args.draft_file}", file=sys.stderr)
+    missing = [p for p in args.draft_file if not p.exists()]
+    if missing:
+        for p in missing:
+            print(f"Error: ファイルが見つかりません: {p}", file=sys.stderr)
         sys.exit(1)
 
-    env_vars = load_env_file(args.env_file)
-    username = get_env("HATENA_USERNAME", env_vars)
-    blog_id = get_env("HATENA_BLOG_ID", env_vars)
-    api_key = get_env("HATENA_API_KEY", env_vars)
+    username, blog_id, api_key = _load_credentials(args.env_file)
 
-    post_draft(args.draft_file, username, blog_id, api_key)
+    if args.sync:
+        sync_entry_ids(args.draft_file, username, blog_id, api_key)
+        return
+
+    for path in args.draft_file:
+        publish_draft(path, username, blog_id, api_key)
 
 
 if __name__ == "__main__":

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -212,13 +212,13 @@ def decide_publish_method(fm: dict[str, str]) -> tuple[str, str | None]:
     - `hatena_entry_id` あり → ("PUT", entry_id)（既存下書きの更新）．
     - それ以外 → ("POST", None)（新規作成）．
     """
-    published = str(fm.get("hatena_published", "")).strip().lower() in _TRUTHY
+    published: bool = str(fm.get("hatena_published", "")).strip().lower() in _TRUTHY
     if published:
         raise ValueError(
             "hatena_published が真のため自動送信を拒否します．"
             "公開後ははてなブログ側を真とし，publish.py からの更新は行いません．"
         )
-    entry_id = fm.get("hatena_entry_id") or None
+    entry_id: str | None = fm.get("hatena_entry_id") or None
     if entry_id:
         return ("PUT", entry_id)
     return ("POST", None)
@@ -235,17 +235,19 @@ def parse_collection_feed(xml_bytes: bytes) -> list[dict]:
     サードパーティ依存ゼロを設計原則とするため `defusedxml` は導入しない．
     expat は外部エンティティ・外部 DTD を解決しないため XXE は対象外である．
     """
-    root = ET.fromstring(xml_bytes)
+    root: ET.Element = ET.fromstring(xml_bytes)
     results: list[dict] = []
     for entry in root.findall(f"{{{ATOM_NS}}}entry"):
-        id_el = entry.find(f"{{{ATOM_NS}}}id")
-        title_el = entry.find(f"{{{ATOM_NS}}}title")
-        draft_el = entry.find(f"{{{APP_NS}}}control/{{{APP_NS}}}draft")
-        id_text = id_el.text if id_el is not None and id_el.text else ""
-        match = re.search(r"-(\d+)$", id_text)
-        entry_id = match.group(1) if match else ""
-        title = title_el.text if title_el is not None and title_el.text else ""
-        draft = (
+        id_el: ET.Element | None = entry.find(f"{{{ATOM_NS}}}id")
+        title_el: ET.Element | None = entry.find(f"{{{ATOM_NS}}}title")
+        draft_el: ET.Element | None = entry.find(
+            f"{{{APP_NS}}}control/{{{APP_NS}}}draft"
+        )
+        id_text: str = id_el.text if id_el is not None and id_el.text else ""
+        match: re.Match[str] | None = re.search(r"-(\d+)$", id_text)
+        entry_id: str = match.group(1) if match else ""
+        title: str = title_el.text if title_el is not None and title_el.text else ""
+        draft: bool = (
             draft_el is not None
             and (draft_el.text or "").strip().lower() == "yes"
         )
@@ -328,7 +330,7 @@ def publish_draft(
         method, entry_id = decide_publish_method(fm)
     except ValueError as exc:
         print(f"Skip: {draft_path}: {exc}", file=sys.stderr)
-        sys.exit(1)
+        return
 
     entry_xml = build_atom_entry(title, body)
     if method == "PUT":
@@ -465,20 +467,31 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    missing = [p for p in args.draft_file if not p.exists()]
+    missing = [p for p in args.draft_file if not p.is_file()]
     if missing:
         for p in missing:
             print(f"Error: ファイルが見つかりません: {p}", file=sys.stderr)
         sys.exit(1)
 
+    if args.env_file != Path(".env") and not args.env_file.is_file():
+        print(
+            f"Error: 指定された環境変数ファイルが見つかりません: {args.env_file}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     username, blog_id, api_key = _load_credentials(args.env_file)
 
-    if args.sync:
-        sync_entry_ids(args.draft_file, username, blog_id, api_key)
-        return
+    try:
+        if args.sync:
+            sync_entry_ids(args.draft_file, username, blog_id, api_key)
+            return
 
-    for path in args.draft_file:
-        publish_draft(path, username, blog_id, api_key)
+        for path in args.draft_file:
+            publish_draft(path, username, blog_id, api_key)
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,7 +1,7 @@
 """publish.py の純粋関数ユニットテスト．
 
 ネットワーク接続が不要な関数のみ対象とする．
-`post_draft` と `main` は統合テスト扱いとし，本ファイルでは扱わない．
+`publish_draft`・`sync_entry_ids`・`main` は統合テスト扱いとし，本ファイルでは扱わない．
 """
 
 from __future__ import annotations
@@ -13,11 +13,16 @@ import pytest
 
 from publish import (
     build_atom_entry,
+    build_collection_url,
+    build_member_url,
     build_wsse_header,
+    decide_publish_method,
     extract_entry_id,
     get_env,
     load_env_file,
+    parse_collection_feed,
     parse_frontmatter,
+    upsert_frontmatter_field,
 )
 
 
@@ -210,3 +215,117 @@ def test_build_wsse_header_nonce_is_random() -> None:
     h1 = build_wsse_header("user", "apikey")
     h2 = build_wsse_header("user", "apikey")
     assert h1 != h2
+
+
+# ---------- build_collection_url / build_member_url ----------
+
+
+def test_build_collection_url() -> None:
+    url = build_collection_url("alice", "alice.hatenablog.com")
+    assert url == "https://blog.hatena.ne.jp/alice/alice.hatenablog.com/atom/entry"
+
+
+def test_build_member_url() -> None:
+    url = build_member_url("alice", "alice.hatenablog.com", "12345678")
+    assert url == "https://blog.hatena.ne.jp/alice/alice.hatenablog.com/atom/entry/12345678"
+
+
+# ---------- decide_publish_method ----------
+
+
+def test_decide_publish_method_post_when_no_entry_id() -> None:
+    assert decide_publish_method({}) == ("POST", None)
+    assert decide_publish_method({"draft_of": "t"}) == ("POST", None)
+
+
+def test_decide_publish_method_put_when_entry_id_present() -> None:
+    assert decide_publish_method({"hatena_entry_id": "999"}) == ("PUT", "999")
+
+
+def test_decide_publish_method_refuses_when_published() -> None:
+    """公開済み（hatena_published: true）の記事は自動送信を拒否する．"""
+    with pytest.raises(ValueError):
+        decide_publish_method({"hatena_entry_id": "999", "hatena_published": "true"})
+
+
+def test_decide_publish_method_published_truthy_variants() -> None:
+    for v in ("true", "True", "yes", "1"):
+        with pytest.raises(ValueError):
+            decide_publish_method({"hatena_entry_id": "999", "hatena_published": v})
+
+
+def test_decide_publish_method_published_false_allows_put() -> None:
+    assert decide_publish_method(
+        {"hatena_entry_id": "999", "hatena_published": "false"}
+    ) == ("PUT", "999")
+
+
+# ---------- parse_collection_feed ----------
+
+
+SAMPLE_FEED = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:app="http://www.w3.org/2007/app">
+  <title>Blog</title>
+  <entry>
+    <id>tag:blog.hatena.ne.jp,2013:blog-alice-12345-6801883189073</id>
+    <title>\xe8\xa8\x98\xe4\xba\x8b A</title>
+    <app:control><app:draft>yes</app:draft></app:control>
+  </entry>
+  <entry>
+    <id>tag:blog.hatena.ne.jp,2013:blog-alice-12345-6801883189099</id>
+    <title>\xe8\xa8\x98\xe4\xba\x8b B</title>
+    <app:control><app:draft>no</app:draft></app:control>
+  </entry>
+</feed>
+"""
+
+
+def test_parse_collection_feed_basic() -> None:
+    entries = parse_collection_feed(SAMPLE_FEED)
+    assert len(entries) == 2
+    assert entries[0] == {
+        "entry_id": "6801883189073",
+        "title": "記事 A",
+        "draft": True,
+    }
+    assert entries[1] == {
+        "entry_id": "6801883189099",
+        "title": "記事 B",
+        "draft": False,
+    }
+
+
+def test_parse_collection_feed_empty() -> None:
+    feed = (
+        b'<?xml version="1.0" encoding="utf-8"?>'
+        b'<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+    )
+    assert parse_collection_feed(feed) == []
+
+
+# ---------- upsert_frontmatter_field ----------
+
+
+def test_upsert_frontmatter_field_inserts_new_key() -> None:
+    text = "---\ndraft_of: t\nmedia: hatena\n---\nbody\n"
+    out = upsert_frontmatter_field(text, "hatena_entry_id", "999")
+    fm, body = parse_frontmatter(out)
+    assert fm["hatena_entry_id"] == "999"
+    assert fm["draft_of"] == "t"
+    assert body == "body\n"
+
+
+def test_upsert_frontmatter_field_replaces_existing_key() -> None:
+    text = "---\ndraft_of: t\nhatena_entry_id: 111\n---\nbody\n"
+    out = upsert_frontmatter_field(text, "hatena_entry_id", "222")
+    fm, _ = parse_frontmatter(out)
+    assert fm["hatena_entry_id"] == "222"
+    assert out.count("hatena_entry_id") == 1
+
+
+def test_upsert_frontmatter_field_preserves_body() -> None:
+    text = "---\ndraft_of: t\n---\nline1\nline2\n"
+    out = upsert_frontmatter_field(text, "k", "v")
+    _, body = parse_frontmatter(out)
+    assert body == "line1\nline2\n"


### PR DESCRIPTION
## 概要

`publish.py` を新規投稿（POST）専用から、既存下書きの更新（PUT）と entry ID 回収（sync）に対応させる．送信済みだが未公開の下書きへ、ファイル側の修正を反映できるようにする．

## 変更点

- frontmatter `hatena_entry_id` の有無で送信メソッドを自動判定する．
  - なし → 新規 `POST`．成功時にレスポンスの entry ID を frontmatter へ書き戻す．
  - あり → 既存下書きの更新 `PUT`（メンバー URI `.../atom/entry/{id}`）．
- `hatena_published: true` のとき自動送信を拒否する安全ガードを追加する（公開後ははてな側を真とする）．
- `--sync`：送信せず、コレクションフィードを取得し title 照合で `hatena_entry_id` を frontmatter へ記録する．
- 複数ファイルの一括送信に対応する．
- `<app:draft>yes</app:draft>` のハードコードと「標準ライブラリのみ・サードパーティ依存ゼロ」の設計原則は維持する．

## テスト

- `tests/test_publish.py` に純粋関数のユニットテストを追加（URL 組み立て・メソッド判定・フィード解析・frontmatter 追記）．
- `pytest`：41 passed．`ruff check`：パス．

## 補足

- XML 解析に `xml.etree.ElementTree` を使用する．入力は認証済みはてな AtomPub API のレスポンスに限り、信頼境界の内側として扱う．`defusedxml` は zero-dependency 原則のため導入せず、その旨をコメントに明記した．

🤖 Generated with [Claude Code](https://claude.com/claude-code)
