### PR TITLE
fix(publish): 照合を ID 主体にし重複作成を防ぐ堅牢化

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.e
 python scripts/publish.py drafts/*.md --sync
 ```
 
-`--verify` は送信せず，各ドラフトの `hatena_entry_id` をメンバー `GET`（`/atom/entry/{id}` の 200／404）で検証する．コレクションフィードは結果整合で取りこぼすため，存在確認はメンバー `GET` を正本とする．
+`--verify` は送信せず，各ドラフトの `hatena_entry_id` をメンバー `GET`（200／404）で検証する．コレクションフィードは結果整合で取りこぼすため，存在確認はメンバー `GET`（`/atom/entry/{id}`）を正本とする．
 
 ```bash
 python scripts/publish.py drafts/*.md --verify

--- a/README.md
+++ b/README.md
@@ -223,16 +223,24 @@ python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.e
 
 常に下書きとして投稿する（`<app:draft>yes</app:draft>` をハードコード）．公開判断ははてなブログ管理画面で人間が行う．
 
-複数ファイルをまとめて送れる．送信メソッドは frontmatter で自動判定する．
+複数ファイルをまとめて送れる．送信メソッドは frontmatter の `hatena_entry_id` を主キーに自動判定する．
 
-- `hatena_entry_id` なし：新規 `POST`．成功時にレスポンスの entry ID を frontmatter へ書き戻す．
-- `hatena_entry_id` あり：既存下書きの更新 `PUT`．未公開の下書きを再送する用途．
+- `hatena_entry_id` あり：既存下書きの更新 `PUT`（常に ID 指定）．未公開の下書きを再送する用途．
+- `hatena_entry_id` なし：新規 `POST`．成功時に entry ID をクォート付きで frontmatter へ書き戻す．
 - `hatena_published: true`：公開後ははてな側を真とするため，自動送信を拒否する（安全ガード）．
 
-`--sync` は送信せず，はてな側のエントリ一覧を取得して title 一致で `hatena_entry_id` を frontmatter へ記録する．送信済みだが ID 未記録の下書きを更新可能にするための回収に使う．
+新規 `POST` の前に，正規化タイトル（空白無視）一致の既存下書きがあれば抑止する．タイトル変更による重複作成を防ぐためであり，意図的な新規作成は `--force-new` を付ける．
+
+`--sync` は送信せず，はてな側のエントリ一覧を取得して正規化タイトル一致で `hatena_entry_id` を frontmatter へ記録する．送信済みだが ID 未記録の下書きを更新可能にするための回収に使う．同名（空白無視）が複数あれば取り違えを避けて記録しない．
 
 ```bash
 python scripts/publish.py drafts/*.md --sync
+```
+
+`--verify` は送信せず，各ドラフトの `hatena_entry_id` をメンバー `GET`（`/atom/entry/{id}` の 200／404）で検証する．コレクションフィードは結果整合で取りこぼすため，存在確認はメンバー `GET` を正本とする．
+
+```bash
+python scripts/publish.py drafts/*.md --verify
 ```
 
 ### テスト

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ python scripts/publish.py drafts/*.md --sync
 python scripts/publish.py drafts/*.md --verify
 ```
 
+欠落（404）や通信エラーが 1 件でもあれば終了コード 1 で終わるため，CI で検証失敗を検知できる．`hatena_entry_id` 未設定は未送信・未回収の通常状態とみなし，失敗には数えない．
+
 ### テスト
 
 ```bash

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -291,7 +291,11 @@ def build_title_index(entries: list[dict]) -> dict[str, list[str]]:
         if not key:
             # 空タイトルは照合キーにしない（空文字列キーへの誤集約・誤一致を防ぐ）．
             continue
-        index.setdefault(key, []).append(entry.get("entry_id", ""))
+        entry_id = entry.get("entry_id") or ""
+        if not entry_id:
+            # entry_id が空のエントリは照合・書き戻しの対象にしない．
+            continue
+        index.setdefault(key, []).append(entry_id)
     return index
 
 
@@ -387,7 +391,12 @@ def entry_exists(
     HTTP 200 → True，404 → False．それ以外の `HTTPError` は再送出する．
     コレクションフィードは結果整合で取りこぼしがあるため，削除・再投稿などの
     破壊的判断はこのメンバー `GET` を根拠にする．
+
+    `entry_id` が空・空白のみの場合はメンバー URI が作れず，コレクション URI への
+    `GET`（フィード）に化けて 200 を誤って返すため，先に False を返す．
     """
+    if not entry_id or not entry_id.strip():
+        return False
     url = build_member_url(username, blog_id, entry_id)
     req = urllib.request.Request(
         url,

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -5,10 +5,15 @@
 - 標準ライブラリのみで実装する．サードパーティ依存ゼロ．
 - `<app:draft>yes</app:draft>` をハードコードし，公開フラグは持たせない．
   公開判断ははてなブログの管理画面で人間が行う．
-- 送信メソッドは frontmatter で自動判定する．
-  `hatena_entry_id` なし → 新規 POST（成功時に entry ID を frontmatter へ書き戻す）．
-  `hatena_entry_id` あり → 既存下書きの更新 PUT．
+- 送信メソッドは frontmatter の `hatena_entry_id` を主キーとして自動判定する．
+  `hatena_entry_id` あり → 既存下書きの更新 PUT（常に ID 指定）．
+  `hatena_entry_id` なし → 新規 POST（成功時に entry ID をクォート付きで書き戻す）．
   `hatena_published: true` → 公開後ははてな側を真とするため自動送信を拒否する．
+  タイトル一致は ID 未設定時の補助に留め，主たる照合には使わない．
+- 新規 POST の前に，正規化タイトル（空白無視）一致の既存下書きがあれば抑止する．
+  意図的に新規作成する場合は `--force-new` を付ける．
+- 存在確認はメンバー `GET`（`/atom/entry/{id}` の 200／404）を正本とする．
+  コレクションフィードは結果整合で取りこぼすため，破壊的判断の根拠にしない．
 - 環境変数（HATENA_USERNAME / HATENA_BLOG_ID / HATENA_API_KEY）は
   `--env-file`（既定: `.env`）から読み込む．
   環境変数に既に設定済みの場合はそちらを優先する（os.environ 優先）．
@@ -18,7 +23,9 @@
 
     python scripts/publish.py drafts/2026-05-07-my-article.md
     python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.env
-    python scripts/publish.py drafts/*.md --sync   # ID 回収のみ（送信しない）
+    python scripts/publish.py drafts/*.md --sync     # ID 回収のみ（送信しない）
+    python scripts/publish.py drafts/*.md --verify   # ID の実在をメンバー GET で検証
+    python scripts/publish.py drafts/new.md --force-new  # 重複抑止を無視して新規 POST
 
 出力:
 
@@ -264,10 +271,67 @@ def parse_feed_next_link(xml_bytes: bytes) -> str | None:
     return None
 
 
-def upsert_frontmatter_field(text: str, key: str, value: str) -> str:
-    """フロントマターへ `key: value` を追記または置換する（本文は保つ）．"""
+def normalize_title(title: str) -> str:
+    """タイトルを正規化する（空白類をすべて除去）．
+
+    全角・半角の空白やタブの有無だけが異なるタイトルを同一視するために使う．
+    文字そのものの違い（例：「学会誌」→「会誌」）は吸収しない．
+    """
+    return re.sub(r"\s+", "", title or "")
+
+
+def build_title_index(entries: list[dict]) -> dict[str, list[str]]:
+    """エントリ一覧から「正規化タイトル → entry_id のリスト」の索引を作る．
+
+    同一の正規化タイトルが複数あれば，出現順で entry_id を集約する．
+    """
+    index: dict[str, list[str]] = {}
+    for entry in entries:
+        key = normalize_title(entry.get("title", ""))
+        if not key:
+            # 空タイトルは照合キーにしない（空文字列キーへの誤集約・誤一致を防ぐ）．
+            continue
+        index.setdefault(key, []).append(entry.get("entry_id", ""))
+    return index
+
+
+def find_title_matches(title: str, index: dict[str, list[str]]) -> list[str]:
+    """正規化タイトルが一致する既存エントリの entry_id 一覧を返す（なければ空）．
+
+    正規化後が空のタイトルは照合対象にせず，常に空リストを返す．
+    """
+    key = normalize_title(title)
+    if not key:
+        return []
+    return index.get(key, [])
+
+
+def should_suppress_new_post(
+    title: str,
+    index: dict[str, list[str]],
+    *,
+    force_new: bool,
+) -> bool:
+    """新規 POST を抑止すべきか判定する．
+
+    正規化タイトル一致の既存エントリがあり，かつ `force_new` でないとき True．
+    """
+    if force_new:
+        return False
+    return bool(find_title_matches(title, index))
+
+
+def upsert_frontmatter_field(
+    text: str, key: str, value: str, *, quote: bool = False
+) -> str:
+    """フロントマターへ `key: value` を追記または置換する（本文は保つ）．
+
+    `quote=True` のとき値をダブルクォートで囲む．`hatena_entry_id` のような
+    19 桁の数値を YAML が浮動小数として精度を落とすのを防ぐ用途で使う．
+    """
     lines = text.splitlines(keepends=True)
-    new_line = f"{key}: {value}\n"
+    rendered = f'"{value}"' if quote else value
+    new_line = f"{key}: {rendered}\n"
     if not lines or lines[0].rstrip() != FRONTMATTER_DELIMITER:
         return f"---\n{new_line}---\n\n{text}"
 
@@ -312,13 +376,48 @@ def _send_entry(
         return resp.read()
 
 
+def entry_exists(
+    username: str,
+    blog_id: str,
+    api_key: str,
+    entry_id: str,
+) -> bool:
+    """メンバー URI を `GET` し，エントリの実在を確認する（存在確認の正本）．
+
+    HTTP 200 → True，404 → False．それ以外の `HTTPError` は再送出する．
+    コレクションフィードは結果整合で取りこぼしがあるため，削除・再投稿などの
+    破壊的判断はこのメンバー `GET` を根拠にする．
+    """
+    url = build_member_url(username, blog_id, entry_id)
+    req = urllib.request.Request(
+        url,
+        headers={"X-WSSE": build_wsse_header(username, api_key)},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30):
+            return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+
+
 def publish_draft(
     draft_path: Path,
     username: str,
     blog_id: str,
     api_key: str,
+    *,
+    existing_index: dict[str, list[str]] | None = None,
+    force_new: bool = False,
 ) -> None:
-    """ドラフトを読み込み，frontmatter に応じて新規 POST か更新 PUT で送る．"""
+    """ドラフトを読み込み，frontmatter に応じて新規 POST か更新 PUT で送る．
+
+    `existing_index` に正規化タイトル索引を渡すと，新規 POST 前に重複候補を照合し
+    抑止する．`None` のとき（既定）は抑止せず従来どおり送信する．`force_new=True`
+    は索引があっても抑止しない．
+    """
     text = draft_path.read_text(encoding="utf-8")
     fm, body = parse_frontmatter(text, source=str(draft_path))
 
@@ -330,6 +429,24 @@ def publish_draft(
         method, entry_id = decide_publish_method(fm)
     except ValueError as exc:
         print(f"Skip: {draft_path}: {exc}", file=sys.stderr)
+        return
+
+    # 新規 POST の前に，正規化タイトル一致の既存下書きがあれば抑止する．
+    # フィードは結果整合のため取りこぼしがありうるが，ここは破壊的でない
+    # 警告・抑止であり，誤検知（取りこぼしによる未警告）でも従来動作に戻るだけ．
+    if (
+        method == "POST"
+        and existing_index is not None
+        and should_suppress_new_post(title, existing_index, force_new=force_new)
+    ):
+        matches = find_title_matches(title, existing_index)
+        print(
+            f"Skip（重複の恐れ）: {draft_path}: "
+            f"同名（空白無視）の既存エントリがあります: {', '.join(matches)}．"
+            "更新する場合は frontmatter に hatena_entry_id を設定するか "
+            "`--sync` で回収してください．意図的な新規作成は `--force-new` を付けます．",
+            file=sys.stderr,
+        )
         return
 
     entry_xml = build_atom_entry(title, body)
@@ -354,7 +471,9 @@ def publish_draft(
     if method == "POST":
         new_id = extract_entry_id(response_body)
         if new_id:
-            updated = upsert_frontmatter_field(text, "hatena_entry_id", new_id)
+            updated = upsert_frontmatter_field(
+                text, "hatena_entry_id", new_id, quote=True
+            )
             draft_path.write_text(updated, encoding="utf-8")
         entry_id = new_id
 
@@ -400,7 +519,10 @@ def sync_entry_ids(
     blog_id: str,
     api_key: str,
 ) -> None:
-    """はてな側の一覧と突合し，title 一致で hatena_entry_id を frontmatter へ書く．"""
+    """はてな側の一覧と突合し，正規化タイトル一致で hatena_entry_id を frontmatter へ書く．
+
+    同名（空白無視）が複数あるときは取り違えを避けて自動記録しない（警告のみ）．
+    """
     try:
         entries = fetch_all_entries(username, blog_id, api_key)
     except urllib.error.HTTPError as exc:
@@ -411,14 +533,7 @@ def sync_entry_ids(
         print(f"Error: {exc.reason}", file=sys.stderr)
         sys.exit(1)
 
-    by_title: dict[str, str] = {}
-    for entry in entries:
-        # 同名が複数あれば最初の 1 件を採用する（重複は警告）．
-        title = entry["title"]
-        if title in by_title and by_title[title] != entry["entry_id"]:
-            print(f"Warning: 同名タイトルが複数あります: {title}", file=sys.stderr)
-            continue
-        by_title.setdefault(title, entry["entry_id"])
+    index = build_title_index(entries)
 
     for path in draft_paths:
         text = path.read_text(encoding="utf-8")
@@ -427,13 +542,63 @@ def sync_entry_ids(
             print(f"Skip（ID 設定済み）: {path}")
             continue
         title = fm.get("draft_of") or path.stem
-        entry_id = by_title.get(title)
-        if not entry_id:
+        matches = find_title_matches(title, index)
+        if not matches:
             print(f"未一致（はてな側に該当なし）: {path}", file=sys.stderr)
             continue
-        updated = upsert_frontmatter_field(text, "hatena_entry_id", entry_id)
+        if len(matches) > 1:
+            # 同名（空白無視）が複数のときは取り違えを避け，自動記録しない．
+            print(
+                f"Warning: 同名（空白無視）が複数あり一意に定まりません: "
+                f"{path}: {', '.join(matches)}",
+                file=sys.stderr,
+            )
+            continue
+        entry_id = matches[0]
+        updated = upsert_frontmatter_field(
+            text, "hatena_entry_id", entry_id, quote=True
+        )
         path.write_text(updated, encoding="utf-8")
         print(f"ID 記録: {path} -> {entry_id}")
+
+
+def verify_entries(
+    draft_paths: list[Path],
+    username: str,
+    blog_id: str,
+    api_key: str,
+) -> None:
+    """各ドラフトの `hatena_entry_id` をメンバー `GET` し，実在を検証する．
+
+    コレクションフィードは結果整合で取りこぼすため，存在確認はメンバー `GET`
+    （200／404）を正本とする．送信や frontmatter の変更は行わない（読み取りのみ）．
+    診断目的のため，1 件のエラーで中断せず各ドラフトを最後まで検証する．
+    """
+    for path in draft_paths:
+        fm, _ = parse_frontmatter(path.read_text(encoding="utf-8"), source=str(path))
+        entry_id = fm.get("hatena_entry_id")
+        if not entry_id:
+            print(f"ID なし（未送信または未回収）: {path}")
+            continue
+        try:
+            exists = entry_exists(username, blog_id, api_key, entry_id)
+        except urllib.error.HTTPError as exc:
+            print(
+                f"Error: HTTP {exc.code} {exc.reason}: {path} (id={entry_id})",
+                file=sys.stderr,
+            )
+            continue
+        except urllib.error.URLError as exc:
+            print(f"Error: {exc.reason}: {path} (id={entry_id})", file=sys.stderr)
+            continue
+        if exists:
+            print(f"OK（実在）: {path} -> {entry_id}")
+        else:
+            print(
+                f"欠落（404・ID が無効）: {path} (id={entry_id})．"
+                "ID の付け間違いか，はてな側で削除された可能性があります．",
+                file=sys.stderr,
+            )
 
 
 def _load_credentials(env_file: Path) -> tuple[str, str, str]:
@@ -463,9 +628,23 @@ def main() -> None:
     parser.add_argument(
         "--sync",
         action="store_true",
-        help="送信せず，はてな側の一覧と title 照合で hatena_entry_id を frontmatter へ記録する",
+        help="送信せず，はてな側の一覧と正規化タイトル照合で hatena_entry_id を frontmatter へ記録する",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="送信せず，各ドラフトの hatena_entry_id をメンバー GET（200／404）で検証する",
+    )
+    parser.add_argument(
+        "--force-new",
+        action="store_true",
+        help="正規化タイトル一致の既存下書きがあっても抑止せず，新規 POST を強行する",
     )
     args = parser.parse_args()
+
+    if args.sync and args.verify:
+        print("Error: --sync と --verify は同時に指定できません．", file=sys.stderr)
+        sys.exit(2)
 
     missing = [p for p in args.draft_file if not p.is_file()]
     if missing:
@@ -487,8 +666,43 @@ def main() -> None:
             sync_entry_ids(args.draft_file, username, blog_id, api_key)
             return
 
+        if args.verify:
+            verify_entries(args.draft_file, username, blog_id, api_key)
+            return
+
+        # 新規 POST 予定（hatena_entry_id 未設定）のドラフトがある場合のみ，
+        # 重複抑止のため一覧を 1 度だけ取得して正規化タイトル索引を作る．
+        existing_index: dict[str, list[str]] | None = None
+        if not args.force_new:
+            needs_index = False
+            for path in args.draft_file:
+                fm, _ = parse_frontmatter(
+                    path.read_text(encoding="utf-8"), source=str(path)
+                )
+                if not fm.get("hatena_entry_id"):
+                    needs_index = True
+                    break
+            if needs_index:
+                existing_index = build_title_index(
+                    fetch_all_entries(username, blog_id, api_key)
+                )
+
         for path in args.draft_file:
-            publish_draft(path, username, blog_id, api_key)
+            publish_draft(
+                path,
+                username,
+                blog_id,
+                api_key,
+                existing_index=existing_index,
+                force_new=args.force_new,
+            )
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8", errors="replace")
+        print(f"Error: HTTP {exc.code} {exc.reason}\n{body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as exc:
+        print(f"Error: {exc.reason}", file=sys.stderr)
+        sys.exit(1)
     except (OSError, ValueError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -394,8 +394,10 @@ def entry_exists(
 
     `entry_id` が空・空白のみの場合はメンバー URI が作れず，コレクション URI への
     `GET`（フィード）に化けて 200 を誤って返すため，先に False を返す．
+    はてなのエントリ ID は ASCII 数字のみで構成される．全角数字や記号混じりは
+    不正な URL 組み立てを招きうるため，送信前に拒否する（不要な通信も避ける）．
     """
-    if not entry_id or not entry_id.strip():
+    if not entry_id or not (entry_id.isascii() and entry_id.isdigit()):
         return False
     url = build_member_url(username, blog_id, entry_id)
     req = urllib.request.Request(

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -484,6 +484,12 @@ def publish_draft(
                 text, "hatena_entry_id", new_id, quote=True
             )
             draft_path.write_text(updated, encoding="utf-8")
+            # 同一バッチ内に同名の新規ドラフトが続く場合の重複 POST を防ぐため，
+            # 送信した ID を索引へ反映し，後続の照合で抑止できるようにする．
+            if existing_index is not None:
+                key = normalize_title(title)
+                if key:
+                    existing_index.setdefault(key, []).append(new_id)
         entry_id = new_id
 
     if entry_id:
@@ -576,13 +582,18 @@ def verify_entries(
     username: str,
     blog_id: str,
     api_key: str,
-) -> None:
+) -> bool:
     """各ドラフトの `hatena_entry_id` をメンバー `GET` し，実在を検証する．
 
     コレクションフィードは結果整合で取りこぼすため，存在確認はメンバー `GET`
     （200／404）を正本とする．送信や frontmatter の変更は行わない（読み取りのみ）．
     診断目的のため，1 件のエラーで中断せず各ドラフトを最後まで検証する．
+
+    検証に失敗した項目（404 の欠落・HTTP／URL エラー）が 1 件でもあれば `False`，
+    すべて健全なら `True` を返す．呼び出し元はこの戻り値で終了コードを決められる．
+    `hatena_entry_id` 未設定は未送信・未回収の通常状態とみなし，失敗に数えない．
     """
+    ok = True
     for path in draft_paths:
         fm, _ = parse_frontmatter(path.read_text(encoding="utf-8"), source=str(path))
         entry_id = fm.get("hatena_entry_id")
@@ -596,9 +607,11 @@ def verify_entries(
                 f"Error: HTTP {exc.code} {exc.reason}: {path} (id={entry_id})",
                 file=sys.stderr,
             )
+            ok = False
             continue
         except urllib.error.URLError as exc:
             print(f"Error: {exc.reason}: {path} (id={entry_id})", file=sys.stderr)
+            ok = False
             continue
         if exists:
             print(f"OK（実在）: {path} -> {entry_id}")
@@ -608,6 +621,8 @@ def verify_entries(
                 "ID の付け間違いか，はてな側で削除された可能性があります．",
                 file=sys.stderr,
             )
+            ok = False
+    return ok
 
 
 def _load_credentials(env_file: Path) -> tuple[str, str, str]:
@@ -676,7 +691,8 @@ def main() -> None:
             return
 
         if args.verify:
-            verify_entries(args.draft_file, username, blog_id, api_key)
+            if not verify_entries(args.draft_file, username, blog_id, api_key):
+                sys.exit(1)
             return
 
         # 新規 POST 予定（hatena_entry_id 未設定）のドラフトがある場合のみ，

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -595,7 +595,7 @@ def verify_entries(
     すべて健全なら `True` を返す．呼び出し元はこの戻り値で終了コードを決められる．
     `hatena_entry_id` 未設定は未送信・未回収の通常状態とみなし，失敗に数えない．
     """
-    ok = True
+    ok: bool = True
     for path in draft_paths:
         fm, _ = parse_frontmatter(path.read_text(encoding="utf-8"), source=str(path))
         entry_id = fm.get("hatena_entry_id")
@@ -701,7 +701,7 @@ def main() -> None:
         # 重複抑止のため一覧を 1 度だけ取得して正規化タイトル索引を作る．
         existing_index: dict[str, list[str]] | None = None
         if not args.force_new:
-            needs_index = False
+            needs_index: bool = False
             for path in args.draft_file:
                 fm, _ = parse_frontmatter(
                     path.read_text(encoding="utf-8"), source=str(path)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,27 +1,36 @@
 """publish.py の純粋関数ユニットテスト．
 
-ネットワーク接続が不要な関数のみ対象とする．
+純粋関数を主対象とする．`entry_exists` のみネットワークを伴うが，
+`urllib.request.urlopen` をモックして単体テストする．
 `publish_draft`・`sync_entry_ids`・`main` は統合テスト扱いとし，本ファイルでは扱わない．
 """
 
 from __future__ import annotations
 
-import sys
+import io
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
 
+import publish
 from publish import (
     build_atom_entry,
     build_collection_url,
     build_member_url,
+    build_title_index,
     build_wsse_header,
     decide_publish_method,
+    entry_exists,
     extract_entry_id,
+    find_title_matches,
     get_env,
     load_env_file,
+    normalize_title,
     parse_collection_feed,
     parse_frontmatter,
+    should_suppress_new_post,
     upsert_frontmatter_field,
 )
 
@@ -329,3 +338,204 @@ def test_upsert_frontmatter_field_preserves_body() -> None:
     out = upsert_frontmatter_field(text, "k", "v")
     _, body = parse_frontmatter(out)
     assert body == "line1\nline2\n"
+
+
+def test_upsert_frontmatter_field_quote_inserts_quoted() -> None:
+    """quote=True で新規キーをダブルクォート付きで書き込む（YAML の精度落ち防止）．"""
+    text = "---\ndraft_of: t\n---\nbody\n"
+    out = upsert_frontmatter_field(text, "hatena_entry_id", "6801883189073", quote=True)
+    assert 'hatena_entry_id: "6801883189073"' in out
+    fm, _ = parse_frontmatter(out)
+    assert fm["hatena_entry_id"] == "6801883189073"
+
+
+def test_upsert_frontmatter_field_quote_replaces_unquoted() -> None:
+    """既存のクォートなしキーを置換しても，書き戻しはクォート付きになる．"""
+    text = "---\ndraft_of: t\nhatena_entry_id: 111\n---\nbody\n"
+    out = upsert_frontmatter_field(text, "hatena_entry_id", "222", quote=True)
+    assert 'hatena_entry_id: "222"' in out
+    assert out.count("hatena_entry_id") == 1
+
+
+def test_upsert_frontmatter_field_default_unquoted() -> None:
+    """quote 省略時は従来どおりクォートなしで書き込む（後方互換）．"""
+    text = "---\ndraft_of: t\n---\nbody\n"
+    out = upsert_frontmatter_field(text, "k", "v")
+    assert "k: v\n" in out
+
+
+# ---------- normalize_title ----------
+
+
+def test_normalize_title_removes_spaces() -> None:
+    assert normalize_title("IPSJ 会誌 編集") == "IPSJ会誌編集"
+
+
+def test_normalize_title_removes_fullwidth_space() -> None:
+    assert normalize_title("記事　A") == "記事A"
+
+
+def test_normalize_title_strips_edges_and_tabs() -> None:
+    assert normalize_title("  a\tb\n") == "ab"
+
+
+def test_normalize_title_empty() -> None:
+    assert normalize_title("") == ""
+
+
+# ---------- build_title_index / find_title_matches ----------
+
+
+def test_build_title_index_groups_by_normalized_title() -> None:
+    entries = [
+        {"entry_id": "1", "title": "記事 A", "draft": True},
+        {"entry_id": "2", "title": "記事A", "draft": True},
+        {"entry_id": "3", "title": "別の記事", "draft": True},
+    ]
+    index = build_title_index(entries)
+    assert index["記事A"] == ["1", "2"]
+    assert index["別の記事"] == ["3"]
+
+
+def test_find_title_matches_returns_candidate_ids() -> None:
+    index = {"記事A": ["1", "2"]}
+    assert find_title_matches("記事 A", index) == ["1", "2"]
+
+
+def test_find_title_matches_empty_when_absent() -> None:
+    assert find_title_matches("未知", {"記事A": ["1"]}) == []
+
+
+# ---------- should_suppress_new_post ----------
+
+
+def test_should_suppress_new_post_true_when_match_and_not_forced() -> None:
+    index = {"記事A": ["1"]}
+    assert should_suppress_new_post("記事 A", index, force_new=False) is True
+
+
+def test_should_suppress_new_post_false_when_forced() -> None:
+    index = {"記事A": ["1"]}
+    assert should_suppress_new_post("記事 A", index, force_new=True) is False
+
+
+def test_should_suppress_new_post_false_when_no_match() -> None:
+    assert should_suppress_new_post("新題", {"記事A": ["1"]}, force_new=False) is False
+
+
+# ---------- entry_exists（メンバー GET・ネットワークはモック） ----------
+
+
+class _FakeResp:
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return b""
+
+
+def test_entry_exists_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: object, timeout: int = 30) -> _FakeResp:
+        return _FakeResp()
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", fake_urlopen)
+    assert entry_exists("u", "b", "k", "123") is True
+
+
+def test_entry_exists_false_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: object, timeout: int = 30) -> _FakeResp:
+        raise urllib.error.HTTPError("url", 404, "Not Found", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", fake_urlopen)
+    assert entry_exists("u", "b", "k", "123") is False
+
+
+def test_entry_exists_raises_on_other_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: object, timeout: int = 30) -> _FakeResp:
+        raise urllib.error.HTTPError("url", 500, "Server Error", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(urllib.error.HTTPError):
+        entry_exists("u", "b", "k", "123")
+
+
+# ---------- 空タイトルの誤一致ガード ----------
+
+
+def test_build_title_index_skips_empty_title() -> None:
+    entries = [{"entry_id": "1", "title": "  ", "draft": True}]
+    assert build_title_index(entries) == {}
+
+
+def test_find_title_matches_empty_title_never_matches() -> None:
+    assert find_title_matches("   ", {"記事A": ["1"]}) == []
+
+
+def test_should_suppress_new_post_false_for_empty_title() -> None:
+    assert should_suppress_new_post("  ", {"記事A": ["1"]}, force_new=False) is False
+
+
+# ---------- publish_draft の POST 重複抑止（_send_entry をモック） ----------
+
+
+def _draft_without_id(tmp_path: Path) -> Path:
+    p = tmp_path / "2026-06-21-sample.md"
+    p.write_text('---\ndraft_of: "記事 A"\n---\n本文\n', encoding="utf-8")
+    return p
+
+
+def test_publish_draft_suppresses_post_on_title_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """正規化タイトル一致の既存エントリがあれば POST せず frontmatter も変えない．"""
+    calls: list[str] = []
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        calls.append(method)
+        return b"<id>tag:...-999</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    p = _draft_without_id(tmp_path)
+    publish.publish_draft(
+        p, "u", "b", "k", existing_index={"記事A": ["1"]}, force_new=False
+    )
+    assert calls == []
+    assert "hatena_entry_id" not in p.read_text(encoding="utf-8")
+
+
+def test_publish_draft_force_new_posts_despite_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """force_new=True なら一致があっても POST し，ID をクォート付きで書き戻す．"""
+    calls: list[str] = []
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        calls.append(method)
+        return b"<id>tag:...-999</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    p = _draft_without_id(tmp_path)
+    publish.publish_draft(
+        p, "u", "b", "k", existing_index={"記事A": ["1"]}, force_new=True
+    )
+    assert calls == ["POST"]
+    assert 'hatena_entry_id: "999"' in p.read_text(encoding="utf-8")
+
+
+def test_publish_draft_no_index_posts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """existing_index=None（既定）のときは抑止せず従来どおり POST する．"""
+    calls: list[str] = []
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        calls.append(method)
+        return b"<id>tag:...-999</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    p = _draft_without_id(tmp_path)
+    publish.publish_draft(p, "u", "b", "k")
+    assert calls == ["POST"]

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -561,3 +561,94 @@ def test_publish_draft_no_index_posts(
     p = _draft_without_id(tmp_path)
     publish.publish_draft(p, "u", "b", "k")
     assert calls == ["POST"]
+
+
+def test_publish_draft_post_updates_existing_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST 成功時，同一バッチ内の後続抑止のため existing_index に新 ID を足す．"""
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        return b"<id>tag:...-999</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    p = _draft_without_id(tmp_path)
+    index: dict[str, list[str]] = {}
+    publish.publish_draft(p, "u", "b", "k", existing_index=index, force_new=False)
+    assert index == {"記事A": ["999"]}
+
+
+def test_publish_draft_second_same_title_suppressed_in_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """同名の新規ドラフトを同じ索引で続けて送ると，2 件目は重複 POST しない．"""
+    calls: list[str] = []
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        calls.append(method)
+        return b"<id>tag:...-999</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    p1 = tmp_path / "2026-06-21-a.md"
+    p1.write_text('---\ndraft_of: "記事 A"\n---\n本文1\n', encoding="utf-8")
+    p2 = tmp_path / "2026-06-21-b.md"
+    p2.write_text('---\ndraft_of: "記事 A"\n---\n本文2\n', encoding="utf-8")
+    index: dict[str, list[str]] = {}
+    publish.publish_draft(p1, "u", "b", "k", existing_index=index, force_new=False)
+    publish.publish_draft(p2, "u", "b", "k", existing_index=index, force_new=False)
+    assert calls == ["POST"]
+    assert "hatena_entry_id" not in p2.read_text(encoding="utf-8")
+
+
+# ---------- verify_entries の戻り値（entry_exists をモック） ----------
+
+
+def _draft_with_id(tmp_path: Path, entry_id: str) -> Path:
+    p = tmp_path / f"2026-06-21-{entry_id or 'noid'}.md"
+    fm = f'hatena_entry_id: "{entry_id}"\n' if entry_id else ""
+    p.write_text(f"---\n{fm}---\n本文\n", encoding="utf-8")
+    return p
+
+
+def test_verify_entries_true_when_all_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """全 ID が実在すれば True を返す．"""
+    monkeypatch.setattr(publish, "entry_exists", lambda u, b, k, i: True)
+    p = _draft_with_id(tmp_path, "123")
+    assert publish.verify_entries([p], "u", "b", "k") is True
+
+
+def test_verify_entries_false_on_missing_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """404（欠落）が 1 件でもあれば False を返す．"""
+    monkeypatch.setattr(publish, "entry_exists", lambda u, b, k, i: False)
+    p = _draft_with_id(tmp_path, "123")
+    assert publish.verify_entries([p], "u", "b", "k") is False
+
+
+def test_verify_entries_missing_id_is_not_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """hatena_entry_id 未設定は未送信・未回収の通常状態で，失敗に数えない．"""
+
+    def boom(u: str, b: str, k: str, i: str) -> bool:
+        raise AssertionError("ID なしで entry_exists を呼んではならない")
+
+    monkeypatch.setattr(publish, "entry_exists", boom)
+    p = _draft_with_id(tmp_path, "")
+    assert publish.verify_entries([p], "u", "b", "k") is True
+
+
+def test_verify_entries_false_on_http_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HTTP エラーは検証不能として False を返す（中断はしない）．"""
+
+    def boom(u: str, b: str, k: str, i: str) -> bool:
+        raise urllib.error.HTTPError("url", 500, "Server Error", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(publish, "entry_exists", boom)
+    p = _draft_with_id(tmp_path, "123")
+    assert publish.verify_entries([p], "u", "b", "k") is False

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -450,6 +450,26 @@ def test_entry_exists_false_for_empty_id_without_network(
     assert entry_exists("u", "b", "k", "   ") is False
 
 
+def test_entry_exists_false_for_non_digit_id_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """数字以外の entry_id はネットワークに出ず False を返す（不正 URL 組み立て防止）．
+
+    はてなのエントリ ID は ASCII 数字のみで構成される．全角数字や記号混じりは
+    パストラバーサルや不正 URL を招きうるため，送信前に拒否する．
+    """
+
+    def boom(req: object, timeout: int = 30) -> _FakeResp:
+        raise AssertionError("urlopen は呼ばれてはならない")
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", boom)
+    assert entry_exists("u", "b", "k", "../../etc/passwd") is False
+    assert entry_exists("u", "b", "k", "abc") is False
+    assert entry_exists("u", "b", "k", "12a") is False
+    assert entry_exists("u", "b", "k", "12 34") is False
+    assert entry_exists("u", "b", "k", "１２３") is False
+
+
 def test_entry_exists_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_urlopen(req: object, timeout: int = 30) -> _FakeResp:
         return _FakeResp()

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -437,6 +437,19 @@ class _FakeResp:
         return b""
 
 
+def test_entry_exists_false_for_empty_id_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """空・空白のみの entry_id はネットワークに出ず False を返す（誤検出防止）．"""
+
+    def boom(req: object, timeout: int = 30) -> _FakeResp:
+        raise AssertionError("urlopen は呼ばれてはならない")
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", boom)
+    assert entry_exists("u", "b", "k", "") is False
+    assert entry_exists("u", "b", "k", "   ") is False
+
+
 def test_entry_exists_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_urlopen(req: object, timeout: int = 30) -> _FakeResp:
         return _FakeResp()
@@ -468,6 +481,15 @@ def test_entry_exists_raises_on_other_http_error(monkeypatch: pytest.MonkeyPatch
 def test_build_title_index_skips_empty_title() -> None:
     entries = [{"entry_id": "1", "title": "  ", "draft": True}]
     assert build_title_index(entries) == {}
+
+
+def test_build_title_index_skips_empty_entry_id() -> None:
+    """entry_id が空のエントリは索引に載せない（空 ID の誤書き戻しを防ぐ）．"""
+    entries = [
+        {"entry_id": "", "title": "記事 A", "draft": True},
+        {"entry_id": "2", "title": "記事 A", "draft": True},
+    ]
+    assert build_title_index(entries) == {"記事A": ["2"]}
 
 
 def test_find_title_matches_empty_title_never_matches() -> None:


### PR DESCRIPTION
## 概要

確定ドラフトのはてな下書き送信（blog-private 2026-06-21 セッション）で，更新されるべき記事が新規投稿となり下書きが重複した．原因はタイトル一致照合と，はてな `AtomPub` コレクションフィードの結果整合である．`publish.py` を ID 主体の照合へ堅牢化し，再発を防ぐ．

Closes #48 ／ #47 を統合．

## 変更点

- 照合・送信判定の主キーを `hatena_entry_id` とする（既存 `decide_publish_method` の ID→PUT を踏襲）．タイトル一致は ID 未設定時の補助に留める．
- 新規 `POST` の前に正規化タイトル（空白無視）一致の既存下書きを照合し，あれば抑止する．意図的な新規作成は `--force-new` で許可．
- `--sync` を正規化タイトル照合へ変更．同名（空白無視）が複数のときは取り違えを避けて自動記録しない（警告のみ）．
- 存在確認はメンバー `GET`（`/atom/entry/{id}` の 200／404）を正本とする `entry_exists` と `--verify` サブコマンドを追加．結果整合のフィードに破壊的判断を依存させない．
- `hatena_entry_id` をクォート付きで書き戻し，19 桁 ID の YAML 精度落ちを防ぐ（#47 統合）．
- `README.md`・モジュール docstring を更新．

## テスト

- `tests/test_publish.py` に純粋関数（`normalize_title`／`build_title_index`／`find_title_matches`／`should_suppress_new_post`），空タイトル誤一致ガード，`entry_exists`（ネットワークはモック），`publish_draft` の抑止／`--force-new` フローのテストを追加．
- publish 単体 63 件・リポジトリ全体 277 件が緑．`ruff check` クリーン．

## 出所

blog-private 2026-06-21 セッションの下書き重複と，その解消で得たフィード結果整合の知見（`docs/notes/2026-06-21-hatena-publish-dedup-and-feed-consistency.md`）から派生．

🤖 Generated with [Claude Code](https://claude.com/claude-code)