### PR TITLE
feat(publish): 既存はてなカテゴリー一覧を出力する --list-categories を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ python scripts/publish.py drafts/*.md --verify
 
 欠落（404）や通信エラーが 1 件でもあれば終了コード 1 で終わるため，CI で検証失敗を検知できる．`hatena_entry_id` 未設定は未送信・未回収の通常状態とみなし，失敗には数えない．
 
+`--list-categories` は送信せず，はてな側の既存カテゴリー term 一覧を 1 行 1 件で標準出力へ出す．本文からのカテゴリー選定（個人化版リポジトリ側のオーケストレーション）が，既存カテゴリーを優先する入力として読み取る窓口である．ドラフトファイルは取らない．他のモード指定（`--sync`／`--verify`）とは併用できない．
+
+```bash
+python scripts/publish.py --list-categories
+```
+
 ### テスト
 
 ```bash

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -28,6 +28,7 @@
     python scripts/publish.py drafts/*.md --sync     # ID 回収のみ（送信しない）
     python scripts/publish.py drafts/*.md --verify   # ID の実在をメンバー GET で検証
     python scripts/publish.py drafts/new.md --force-new  # 重複抑止を無視して新規 POST
+    python scripts/publish.py --list-categories      # 既存カテゴリー term 一覧を出力
 
 出力:
 
@@ -696,6 +697,20 @@ def fetch_categories(
     return parse_category_document(xml_bytes)
 
 
+def list_categories(
+    username: str,
+    blog_id: str,
+    api_key: str,
+) -> None:
+    """既存カテゴリーの term 一覧を 1 行 1 件で標準出力へ出す．
+
+    本文からのカテゴリー選定（blog-private 側オーケストレーション）が，
+    既存カテゴリーを優先する入力として読み取るための窓口とする．
+    """
+    for term in fetch_categories(username, blog_id, api_key):
+        print(term)
+
+
 def sync_entry_ids(
     draft_paths: list[Path],
     username: str,
@@ -808,7 +823,7 @@ def main() -> None:
     parser.add_argument(
         "draft_file",
         type=Path,
-        nargs="+",
+        nargs="*",
         help="対象の Markdown ドラフトファイル（複数可）",
     )
     parser.add_argument(
@@ -832,17 +847,28 @@ def main() -> None:
         action="store_true",
         help="正規化タイトル一致の既存下書きがあっても抑止せず，新規 POST を強行する",
     )
+    parser.add_argument(
+        "--list-categories",
+        action="store_true",
+        help="送信せず，はてな側の既存カテゴリー term 一覧を 1 行 1 件で標準出力へ出す",
+    )
     args = parser.parse_args()
 
-    if args.sync and args.verify:
-        print("Error: --sync と --verify は同時に指定できません．", file=sys.stderr)
+    selected_modes = [
+        name
+        for name, on in (
+            ("--sync", args.sync),
+            ("--verify", args.verify),
+            ("--list-categories", args.list_categories),
+        )
+        if on
+    ]
+    if len(selected_modes) > 1:
+        print(
+            f"Error: {' と '.join(selected_modes)} は同時に指定できません．",
+            file=sys.stderr,
+        )
         sys.exit(2)
-
-    missing = [p for p in args.draft_file if not p.is_file()]
-    if missing:
-        for p in missing:
-            print(f"Error: ファイルが見つかりません: {p}", file=sys.stderr)
-        sys.exit(1)
 
     if args.env_file != Path(".env") and not args.env_file.is_file():
         print(
@@ -851,9 +877,33 @@ def main() -> None:
         )
         sys.exit(2)
 
+    if args.list_categories:
+        if args.draft_file:
+            print(
+                "Error: --list-categories はドラフトファイルを取りません．",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+    else:
+        if not args.draft_file:
+            print(
+                "Error: 対象のドラフトファイルを 1 つ以上指定してください．",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        missing = [p for p in args.draft_file if not p.is_file()]
+        if missing:
+            for p in missing:
+                print(f"Error: ファイルが見つかりません: {p}", file=sys.stderr)
+            sys.exit(1)
+
     username, blog_id, api_key = _load_credentials(args.env_file)
 
     try:
+        if args.list_categories:
+            list_categories(username, blog_id, api_key)
+            return
+
         if args.sync:
             sync_entry_ids(args.draft_file, username, blog_id, api_key)
             return

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -28,6 +28,7 @@ from publish import (
     fetch_categories,
     find_title_matches,
     get_env,
+    list_categories,
     load_env_file,
     normalize_categories,
     normalize_title,
@@ -989,3 +990,39 @@ def test_publish_draft_warns_when_over_max_categories(
     publish.publish_draft(p, "u", "b", "k")
     captured = capsys.readouterr()
     assert "10" in captured.err
+
+
+# ---------- list_categories（標準出力・ネットワークはモック） ----------
+
+
+def test_list_categories_prints_terms_one_per_line(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """既存カテゴリーの term を 1 行 1 件で標準出力へ出す．"""
+
+    def fake_urlopen(req: object, timeout: int = 30) -> _FakeCategoryResp:
+        return _FakeCategoryResp(SAMPLE_CATEGORY_DOC)
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", fake_urlopen)
+    list_categories("u", "b", "k")
+    captured = capsys.readouterr()
+    assert captured.out == "Perl\nコミュニティ\n"
+
+
+def test_list_categories_empty_prints_nothing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """カテゴリーが無ければ標準出力は空とする．"""
+    empty_doc = (
+        b'<?xml version="1.0" encoding="utf-8"?>'
+        b'<app:categories xmlns:app="http://www.w3.org/2007/app" '
+        b'xmlns:atom="http://www.w3.org/2005/Atom" fixed="no"></app:categories>'
+    )
+
+    def fake_urlopen(req: object, timeout: int = 30) -> _FakeCategoryResp:
+        return _FakeCategoryResp(empty_doc)
+
+    monkeypatch.setattr(publish.urllib.request, "urlopen", fake_urlopen)
+    list_categories("u", "b", "k")
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
## 概要

`publish.py` に `--list-categories` モードを追加する．送信せず，はてな側の既存カテゴリー term 一覧を 1 行 1 件で標準出力へ出す．本文からのカテゴリー選定オーケストレーション（tomio2480/blog-private#68）が，既存カテゴリーを優先入力として読み取る窓口となる．

#44（PR #52）で実装済みの `fetch_categories` を再利用する．送信機構には手を入れない．

## 変更点

- `list_categories(username, blog_id, api_key)` を追加．`fetch_categories` の結果を 1 行 1 件で `print` する．
- `main()` に `--list-categories` フラグを追加．
  - `draft_file` を `nargs="+"` から `nargs="*"` へ変更し，`--list-categories` 単体起動を許す．
  - `--list-categories` はドラフトファイルを取らない（指定時は exit 2）．
  - モード指定（`--sync`／`--verify`／`--list-categories`）の同時指定は exit 2 で弾く．
  - ファイル必須チェックは送信系モードのみに適用する．
- モジュール docstring・README に使い方を追記．

## テスト

- `list_categories` の単体テスト 2 件を追加（term 出力・空一覧）．`urlopen` をモックする．
- publish スイート全体で 106 passed．`ruff check` も通過．
- CLI のエラー経路（引数なし・モード併用・`--list-categories` へのファイル指定）が exit 2 になることを実機確認．

## 関連

- enables tomio2480/blog-private#68
- 依存元：#44（PR #52，カテゴリー送信機構・一覧取得）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
