### PR TITLE
feat(publish): はてなフォトライフ画像アップロード基盤を実装する

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -618,7 +618,12 @@ def load_upload_map(path: Path) -> dict[str, str]:
     raw = path.read_text(encoding="utf-8")
     if not raw.strip():
         return {}
-    data = json.loads(raw)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"アップロード記録の JSON 解析に失敗しました: {path}"
+        ) from exc
     if not isinstance(data, dict):
         raise ValueError(
             f"アップロード記録の形式が不正です（最上位は辞書である必要があります）: {path}"
@@ -631,7 +636,11 @@ def load_upload_map(path: Path) -> dict[str, str]:
 
 
 def save_upload_map(path: Path, mapping: dict[str, str]) -> None:
-    """アップロード記録を JSON で書き出す（キー順に整列し差分を安定させる）．"""
+    """アップロード記録を JSON で書き出す（キー順に整列し差分を安定させる）．
+
+    親ディレクトリが無い場合は作成してから書き込む（`FileNotFoundError` を防ぐ）．
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True)
     path.write_text(text + "\n", encoding="utf-8")
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -623,6 +623,10 @@ def load_upload_map(path: Path) -> dict[str, str]:
         raise ValueError(
             f"アップロード記録の形式が不正です（最上位は辞書である必要があります）: {path}"
         )
+    if not all(isinstance(k, str) and isinstance(v, str) for k, v in data.items()):
+        raise ValueError(
+            f"アップロード記録の形式が不正です（キーと値は文字列である必要があります）: {path}"
+        )
     return data
 
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -42,6 +42,7 @@ import argparse
 import base64
 import hashlib
 import html
+import json
 import os
 import re
 import sys
@@ -67,6 +68,26 @@ _TRUTHY = {"true", "yes", "1", "on"}
 
 # はてなカテゴリーの推奨上限（これを超えると警告する）
 CATEGORY_MAX = 10
+
+# はてなフォトライフ AtomPub の投稿先（PostURI）
+FOTOLIFE_POST_URL = "https://f.hatena.ne.jp/atom/post"
+
+# フォトライフのエントリは Atom 0.3 名前空間を使う（ブログ API の Atom とは別）
+FOTOLIFE_ATOM_NS = "http://purl.org/atom/ns#"
+
+# フォルダ指定に使う Dublin Core 名前空間
+DC_NS = "http://purl.org/dc/elements/1.1/"
+
+# フォルダ未指定時の既定フォルダ名（ブログ用画像をまとめる）
+FOTOLIFE_DEFAULT_FOLDER = "blog"
+
+# 拡張子から content-type を引く対応表（マジックバイト判定の補助）
+_IMAGE_EXT_CONTENT_TYPE = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+}
 
 
 def build_collection_url(username: str, blog_id: str) -> str:
@@ -515,6 +536,137 @@ def _send_entry(
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
         return resp.read()
+
+
+def detect_image_content_type(data: bytes, *, filename: str | None = None) -> str:
+    """画像バイト列から content-type を判定する．
+
+    先頭のマジックバイトを優先し，判定できない場合は `filename` の拡張子で補う．
+    どちらでも判定できなければ `ValueError` を送出する（未対応形式を早期に弾く）．
+
+    対応形式は jpeg / png / gif とする．
+    """
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if filename:
+        ext = Path(filename).suffix.lower()
+        content_type = _IMAGE_EXT_CONTENT_TYPE.get(ext)
+        if content_type:
+            return content_type
+    raise ValueError(
+        f"未対応の画像形式です（jpeg / png / gif のみ対応）: filename={filename!r}"
+    )
+
+
+def build_fotolife_entry(
+    image_data: bytes,
+    content_type: str,
+    title: str,
+    folder: str = FOTOLIFE_DEFAULT_FOLDER,
+) -> bytes:
+    """フォトライフ AtomPub の投稿用エントリ XML を生成する．
+
+    画像は Base64 化して `<content mode="base64" type="image/...">` で載せる．
+    `folder` を渡すと `<dc:subject>` でフォルダを指定する（空文字なら省略）．
+    フォトライフのエントリは Atom 0.3 名前空間（`FOTOLIFE_ATOM_NS`）を使う．
+    """
+    title_esc = html.escape(title)
+    content_type_esc = html.escape(content_type, quote=True)
+    b64 = base64.b64encode(image_data).decode("ascii")
+    subject_xml = ""
+    if folder:
+        folder_esc = html.escape(folder)
+        subject_xml = (
+            f'  <dc:subject xmlns:dc="{DC_NS}">{folder_esc}</dc:subject>\n'
+        )
+    xml = (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<entry xmlns="{FOTOLIFE_ATOM_NS}">\n'
+        f"  <title>{title_esc}</title>\n"
+        f'  <content mode="base64" type="{content_type_esc}">{b64}</content>\n'
+        f"{subject_xml}"
+        "</entry>\n"
+    )
+    return xml.encode("utf-8")
+
+
+def extract_fotolife_syntax(response_body: bytes) -> str:
+    """フォトライフの投稿レスポンスから `hatena:syntax` の f:id 記法を取り出す．
+
+    レスポンスは `<hatena:syntax>f:id:USER:XXXX:image</hatena:syntax>` を含む．
+    名前空間宣言の有無に依らず取り出せるよう，要素名で正規表現照合する．
+    見つからなければ空文字を返す（呼び出し側でアップロード失敗を判定する）．
+    """
+    match = re.search(rb"<hatena:syntax>([^<]+)</hatena:syntax>", response_body)
+    if match:
+        return match.group(1).decode("utf-8").strip()
+    return ""
+
+
+def load_upload_map(path: Path) -> dict[str, str]:
+    """アップロード記録（内容ハッシュ → f:id 記法）を読み込む．
+
+    ファイルが無い・空のときは空辞書を返す．JSON の最上位が辞書でない場合は
+    記録が壊れているとみなし `ValueError` を送出する（黙って握りつぶさない）．
+    """
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"アップロード記録の形式が不正です（最上位は辞書である必要があります）: {path}"
+        )
+    return data
+
+
+def save_upload_map(path: Path, mapping: dict[str, str]) -> None:
+    """アップロード記録を JSON で書き出す（キー順に整列し差分を安定させる）．"""
+    text = json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def upload_image(
+    image_path: Path,
+    username: str,
+    api_key: str,
+    *,
+    folder: str = FOTOLIFE_DEFAULT_FOLDER,
+    map_path: Path | None = None,
+) -> str:
+    """画像をフォトライフへアップロードし，f:id 記法を返す．
+
+    `map_path` を渡すと内容ハッシュ（SHA-256）で既存記録を照合し，同一内容の
+    画像は再アップロードせず記録済みの f:id 記法を返す．新規アップロード時は
+    記録を更新する．応答から f:id 記法を取得できない場合は `ValueError` とする．
+    """
+    data = image_path.read_bytes()
+    content_key = hashlib.sha256(data).hexdigest()
+    upload_map = load_upload_map(map_path) if map_path is not None else {}
+    cached = upload_map.get(content_key)
+    if cached:
+        return cached
+
+    content_type = detect_image_content_type(data, filename=image_path.name)
+    entry_xml = build_fotolife_entry(data, content_type, image_path.stem, folder)
+    response_body = _send_entry(
+        FOTOLIFE_POST_URL, entry_xml, username, api_key, "POST"
+    )
+    syntax = extract_fotolife_syntax(response_body)
+    if not syntax:
+        raise ValueError(
+            f"アップロード応答から f:id 記法を取得できませんでした: {image_path}"
+        )
+    if map_path is not None:
+        upload_map[content_key] = syntax
+        save_upload_map(map_path, upload_map)
+    return syntax
 
 
 def entry_exists(

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -598,12 +598,21 @@ def extract_fotolife_syntax(response_body: bytes) -> str:
     """フォトライフの投稿レスポンスから `hatena:syntax` の f:id 記法を取り出す．
 
     レスポンスは `<hatena:syntax>f:id:USER:XXXX:image</hatena:syntax>` を含む．
-    名前空間宣言の有無に依らず取り出せるよう，要素名で正規表現照合する．
-    見つからなければ空文字を返す（呼び出し側でアップロード失敗を判定する）．
+    名前空間接頭辞の変更や属性・改行に影響されないよう，`{*}syntax` の
+    ワイルドカード名前空間でローカル名照合する．見つからない・整形式でない場合は
+    空文字を返す（呼び出し側でアップロード失敗を判定する）．
+
+    入力は認証済みはてな AtomPub API（HTTPS）のレスポンスに限るため信頼境界の
+    内側として扱う．stdlib の expat は外部エンティティ・DTD を解決しないため
+    XXE は対象外である（`parse_collection_feed` と同方針）．
     """
-    match = re.search(rb"<hatena:syntax>([^<]+)</hatena:syntax>", response_body)
-    if match:
-        return match.group(1).decode("utf-8").strip()
+    try:
+        root = ET.fromstring(response_body)
+    except ET.ParseError:
+        return ""
+    syntax_text = root.findtext(".//{*}syntax")
+    if syntax_text:
+        return syntax_text.strip()
     return ""
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1121,6 +1121,20 @@ def test_extract_fotolife_syntax_empty_when_absent() -> None:
     assert extract_fotolife_syntax(b"<entry></entry>") == ""
 
 
+def test_extract_fotolife_syntax_handles_other_prefix() -> None:
+    """名前空間接頭辞が変わっても要素のローカル名で取り出せる．"""
+    resp = (
+        b'<entry xmlns:h="http://www.hatena.ne.jp/info/xmlns#">'
+        b"<h:syntax>f:id:u:1:image</h:syntax></entry>"
+    )
+    assert extract_fotolife_syntax(resp) == "f:id:u:1:image"
+
+
+def test_extract_fotolife_syntax_empty_on_malformed_xml() -> None:
+    """整形式でない XML は空文字を返す（呼び出し側がアップロード失敗を判定する）．"""
+    assert extract_fotolife_syntax(b"<entry><hatena:syntax>broken") == ""
+
+
 # ---------- load_upload_map / save_upload_map ----------
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1060,6 +1060,14 @@ def test_detect_image_content_type_extension_fallback() -> None:
         detect_image_content_type(b"\x00\x01\x02\x03", filename="photo.JPG")
         == "image/jpeg"
     )
+    assert (
+        detect_image_content_type(b"\x00\x01\x02\x03", filename="photo.PNG")
+        == "image/png"
+    )
+    assert (
+        detect_image_content_type(b"\x00\x01\x02\x03", filename="photo.GIF")
+        == "image/gif"
+    )
 
 
 def test_detect_image_content_type_rejects_unknown() -> None:
@@ -1135,6 +1143,14 @@ def test_load_upload_map_empty_file_returns_empty(tmp_path: Path) -> None:
 def test_load_upload_map_rejects_non_dict(tmp_path: Path) -> None:
     p = tmp_path / "uploads.json"
     p.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_upload_map(p)
+
+
+def test_load_upload_map_rejects_non_str_value(tmp_path: Path) -> None:
+    """値が文字列でない記録は破損とみなして弾く（型の暗黙伝播を防ぐ）．"""
+    p = tmp_path / "uploads.json"
+    p.write_text('{"abc": 123}', encoding="utf-8")
     with pytest.raises(ValueError):
         load_upload_map(p)
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import base64
 import io
 import urllib.error
 import urllib.request
@@ -19,22 +20,27 @@ from publish import (
     build_atom_entry,
     build_category_url,
     build_collection_url,
+    build_fotolife_entry,
     build_member_url,
     build_title_index,
     build_wsse_header,
     decide_publish_method,
+    detect_image_content_type,
     entry_exists,
     extract_entry_id,
+    extract_fotolife_syntax,
     fetch_categories,
     find_title_matches,
     get_env,
     list_categories,
     load_env_file,
+    load_upload_map,
     normalize_categories,
     normalize_title,
     parse_category_document,
     parse_collection_feed,
     parse_frontmatter,
+    save_upload_map,
     should_suppress_new_post,
     upsert_frontmatter_field,
 )
@@ -1026,3 +1032,169 @@ def test_list_categories_empty_prints_nothing(
     list_categories("u", "b", "k")
     captured = capsys.readouterr()
     assert captured.out == ""
+
+
+# ---------- detect_image_content_type ----------
+
+_JPEG_MAGIC = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+_GIF_MAGIC = b"GIF89a\x01\x00\x01\x00"
+
+
+def test_detect_image_content_type_jpeg_by_magic() -> None:
+    assert detect_image_content_type(_JPEG_MAGIC) == "image/jpeg"
+
+
+def test_detect_image_content_type_png_by_magic() -> None:
+    assert detect_image_content_type(_PNG_MAGIC) == "image/png"
+
+
+def test_detect_image_content_type_gif_by_magic() -> None:
+    assert detect_image_content_type(b"GIF87a\x00\x00") == "image/gif"
+    assert detect_image_content_type(_GIF_MAGIC) == "image/gif"
+
+
+def test_detect_image_content_type_extension_fallback() -> None:
+    """マジックバイトで判定できなくても拡張子から判定する（大文字も許容）．"""
+    assert (
+        detect_image_content_type(b"\x00\x01\x02\x03", filename="photo.JPG")
+        == "image/jpeg"
+    )
+
+
+def test_detect_image_content_type_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        detect_image_content_type(b"\x00\x01\x02\x03", filename="data.txt")
+    with pytest.raises(ValueError):
+        detect_image_content_type(b"\x00\x01\x02\x03")
+
+
+# ---------- build_fotolife_entry ----------
+
+
+def test_build_fotolife_entry_includes_base64_content() -> None:
+    xml = build_fotolife_entry(b"hello", "image/png", "タイトル").decode("utf-8")
+    assert 'xmlns="http://purl.org/atom/ns#"' in xml
+    assert "<title>タイトル</title>" in xml
+    assert '<content mode="base64" type="image/png">' in xml
+    assert base64.b64encode(b"hello").decode("ascii") in xml
+
+
+def test_build_fotolife_entry_sets_folder_via_dc_subject() -> None:
+    xml = build_fotolife_entry(b"x", "image/jpeg", "t", folder="blog").decode("utf-8")
+    assert (
+        '<dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">blog</dc:subject>'
+        in xml
+    )
+
+
+def test_build_fotolife_entry_omits_subject_when_folder_empty() -> None:
+    xml = build_fotolife_entry(b"x", "image/jpeg", "t", folder="").decode("utf-8")
+    assert "dc:subject" not in xml
+
+
+def test_build_fotolife_entry_escapes_title() -> None:
+    xml = build_fotolife_entry(b"x", "image/png", "a & <b>").decode("utf-8")
+    assert "a &amp; &lt;b&gt;" in xml
+
+
+# ---------- extract_fotolife_syntax ----------
+
+
+def test_extract_fotolife_syntax_returns_fid() -> None:
+    resp = (
+        b'<entry xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#">'
+        b"<hatena:syntax>f:id:naoya:20060101120000:image</hatena:syntax></entry>"
+    )
+    assert extract_fotolife_syntax(resp) == "f:id:naoya:20060101120000:image"
+
+
+def test_extract_fotolife_syntax_empty_when_absent() -> None:
+    assert extract_fotolife_syntax(b"<entry></entry>") == ""
+
+
+# ---------- load_upload_map / save_upload_map ----------
+
+
+def test_load_upload_map_missing_returns_empty(tmp_path: Path) -> None:
+    assert load_upload_map(tmp_path / "nope.json") == {}
+
+
+def test_save_then_load_upload_map_roundtrip(tmp_path: Path) -> None:
+    p = tmp_path / "uploads.json"
+    save_upload_map(p, {"abc": "f:id:u:1:image"})
+    assert load_upload_map(p) == {"abc": "f:id:u:1:image"}
+
+
+def test_load_upload_map_empty_file_returns_empty(tmp_path: Path) -> None:
+    p = tmp_path / "uploads.json"
+    p.write_text("", encoding="utf-8")
+    assert load_upload_map(p) == {}
+
+
+def test_load_upload_map_rejects_non_dict(tmp_path: Path) -> None:
+    p = tmp_path / "uploads.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_upload_map(p)
+
+
+# ---------- upload_image（ネットワークはモック） ----------
+
+_FOTOLIFE_RESP = (
+    b'<entry xmlns="http://purl.org/atom/ns#" '
+    b'xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#">'
+    b"<hatena:syntax>f:id:testuser:20260621120000:image</hatena:syntax>"
+    b"</entry>"
+)
+_PNG_IMAGE = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRbody"
+
+
+def test_upload_image_posts_and_returns_syntax(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    img = tmp_path / "pic.png"
+    img.write_bytes(_PNG_IMAGE)
+    calls: list[tuple[str, str]] = []
+
+    def fake_send(
+        url: str, entry_xml: bytes, username: str, api_key: str, method: str
+    ) -> bytes:
+        calls.append((url, method))
+        return _FOTOLIFE_RESP
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    syntax = publish.upload_image(img, "testuser", "key")
+    assert syntax == "f:id:testuser:20260621120000:image"
+    assert calls == [("https://f.hatena.ne.jp/atom/post", "POST")]
+
+
+def test_upload_image_skips_when_already_uploaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """同一内容の画像は記録を参照して再アップロードしない．"""
+    img = tmp_path / "pic.png"
+    img.write_bytes(_PNG_IMAGE)
+    map_path = tmp_path / "uploads.json"
+
+    monkeypatch.setattr(
+        publish, "_send_entry", lambda *a, **k: _FOTOLIFE_RESP
+    )
+    first = publish.upload_image(img, "testuser", "key", map_path=map_path)
+
+    def boom(*a: object, **k: object) -> bytes:
+        raise AssertionError("二重アップロードしてはならない")
+
+    monkeypatch.setattr(publish, "_send_entry", boom)
+    second = publish.upload_image(img, "testuser", "key", map_path=map_path)
+    assert first == second == "f:id:testuser:20260621120000:image"
+
+
+def test_upload_image_raises_when_no_syntax(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    img = tmp_path / "pic.png"
+    img.write_bytes(_PNG_IMAGE)
+    monkeypatch.setattr(publish, "_send_entry", lambda *a, **k: b"<entry></entry>")
+    with pytest.raises(ValueError):
+        publish.upload_image(img, "testuser", "key")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1134,6 +1134,22 @@ def test_save_then_load_upload_map_roundtrip(tmp_path: Path) -> None:
     assert load_upload_map(p) == {"abc": "f:id:u:1:image"}
 
 
+def test_save_upload_map_creates_parent_dirs(tmp_path: Path) -> None:
+    """親ディレクトリが無くても作成して書き込む（FileNotFoundError を防ぐ）．"""
+    p = tmp_path / "nested" / "dir" / "uploads.json"
+    save_upload_map(p, {"abc": "f:id:u:1:image"})
+    assert load_upload_map(p) == {"abc": "f:id:u:1:image"}
+
+
+def test_load_upload_map_wraps_corrupt_json_with_path(tmp_path: Path) -> None:
+    """壊れた JSON は ValueError とし，メッセージにパスを含める（識別容易化）．"""
+    p = tmp_path / "uploads.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(ValueError) as exc:
+        load_upload_map(p)
+    assert str(p) in str(exc.value)
+
+
 def test_load_upload_map_empty_file_returns_empty(tmp_path: Path) -> None:
     p = tmp_path / "uploads.json"
     p.write_text("", encoding="utf-8")


### PR DESCRIPTION
## 概要

はてなフォトライフ AtomPub API へ画像をアップロードし，応答から `f:id` 記法を得る基盤を追加する（Issue #45）．本文への設置（Markdown 画像記法の置換・figure 化）は別 Issue #46 で扱う．

セルフコードレビュー実施済み（`self-reviewer` 一次走査 + `/security-review` 統合）．HIGH-CONFIDENCE な脆弱性なし．low 指摘 3 件のうち妥当な 2 件（値型検証・拡張子テスト補強）を反映済み．

## 変更内容

`scripts/publish.py` に以下を追加（標準ライブラリのみ・サードパーティ依存ゼロを維持）．

| 関数 | 役割 |
|---|---|
| `detect_image_content_type` | マジックバイト優先・拡張子フォールバックで jpeg / png / gif を判定 |
| `build_fotolife_entry` | Atom 0.3 名前空間（`http://purl.org/atom/ns#`）で `content`(base64) と `dc:subject` を生成 |
| `extract_fotolife_syntax` | 応答の `hatena:syntax` から f:id 記法を正規表現で抽出 |
| `load_upload_map` / `save_upload_map` | アップロード記録（JSON）の読み書き．最上位 dict とキー・値の文字列性を検証 |
| `upload_image` | 内容ハッシュ（SHA-256）で同一画像の二重アップロードを防止 |

- WSSE は既存 `build_wsse_header`，送信は既存 `_send_entry` を再利用（Issue が求める共通化）．
- エンドポイント `https://f.hatena.ne.jp/atom/post`．認証は WSSE．
- 既定フォルダは `blog`（`dc:subject`）．

## 設計判断

- f:id 記法は応答どおり `f:id:...:image` を返す．本文へ埋める `[...]` 化は #46 の責務とする．
- 二重アップロード防止のキーは内容ハッシュ（SHA-256）とし，リネーム・移動した同一画像も同一視する．SHA-256 は内容識別用途で認証ではない．

## テスト（TDD）

- Red → Green を踏んで純粋関数を中心に 20 件追加．ネットワークは `_send_entry` / `urlopen` をモック．
- スイート全体 **339 passed**．

## ドキュメント整合性

- #45 は CLI 表面（argparse フラグ）を持たない基盤追加のため，README のユーザー向け記述に変更は不要．CLI 連携は #46 で扱う．

## 関連

- Closes #45
- 後続: #46（本文への画像設置）が本 PR のアップローダに依存する．