### PR TITLE
docs: transcribe_audio.py をドキュメントへ反映し CLI フラグを追記する

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@
 ```
 [人間 録音]
     ↓
-[whisper.cpp 文字起こし]  vocabulary.yml の canonical 語を --prompt へ注入
+[transcribe_audio.py]  whisper.cpp で文字起こし（vocabulary.yml を --prompt 注入）
     ↓
 [人間 メモ Markdown 手書き]  音声と共通の basename で対応づけ
     ↓
@@ -78,8 +78,9 @@
 ```
 blog-pipeline/
 ├─ scripts/
-│  ├─ parse_enex.py           ENEX → Markdown（非推奨．旧素材変換用）
+│  ├─ transcribe_audio.py     録音音声 → 生の文字起こし（whisper.cpp，フェーズ 7）
 │  ├─ build_material.py       人間メモ + 生文字起こし → 2 セクション素材（フェーズ 7）
+│  ├─ parse_enex.py           ENEX → Markdown（非推奨．旧素材変換用）
 │  ├─ list_materials.py       素材一覧の取得
 │  ├─ build_dictionary.py     形態素解析で固有名詞辞書を更新
 │  ├─ publish.py              AtomPub 投稿・更新（常に下書き）

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 `parse_enex.py`・`list_materials.py`・`publish.py` は標準ライブラリのみで実装している．
 `prompt-maker/generate_prompts.py` も同様である．
 `build_dictionary.py` は形態素解析のため `janome` と `pyyaml` を使用する．
-`build_material.py` は人間メモのフロントマター解析のため `pyyaml` を使用する．
+`build_material.py` と `transcribe_audio.py` はフロントマター解析・辞書注入のため `pyyaml` を使用する．
 テストは `pytest` を使う．
 
 ### Python 環境
@@ -154,6 +154,7 @@ python scripts/transcribe_audio.py \
 ただし初期プロンプトは soft hint であり，誤認識の残りは後段の `transcript-corrector` で補正する前提とする．
 入力音声と中間 WAV，生の文字起こしは再生成できるため `.scratch/` 配下など Git 管理外へ出力する．
 `ffmpeg` は PATH 上にある前提とする．
+環境変数を `.env` から読みたい場合は `--env-file` を指定する（既定は `.env`）．`publish.py` と同じ規約である．
 
 ### `build_material.py` の使い方
 
@@ -171,6 +172,7 @@ python scripts/build_material.py \
 `note_title` と `created` は人間メモのファイル名 stem から導出する．
 人間メモがフロントマターを持つ場合は `tags` 等を引き継ぐ．
 フロントマターの `source` は `audio` で固定する．
+人間メモと文字起こしのファイル名 stem が異なる場合は `--allow-mismatched-basename` を付ける．
 
 ### `build_dictionary.py` の使い方
 


### PR DESCRIPTION
## 概要

`blog-private` と `blog-pipeline` の齟齬突合のうち，`blog-pipeline` 側の修正．フェーズ 7 で新設した `transcribe_audio.py` が構成ツリーと依存節へ未掲載だったため，実装に合わせて整合させる．

本リポジトリのドキュメントは画像対応作業の際に大半が更新済みであり，残っていた齟齬は小規模であった．

## 変更内容
- `ARCHITECTURE.md`：`scripts/` ツリーへ `transcribe_audio.py` を追加．パイプライン図のステップ名を実スクリプト名（`transcribe_audio.py`）へ統一
- `README.md`：`transcribe_audio.py` の `pyyaml` 依存を明記．`--env-file`（`transcribe_audio.py`）と `--allow-mismatched-basename`（`build_material.py`）の使い方を追記

## 確認
- `python -m pytest`：368 passed（ドキュメントのみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
