### PR TITLE
docs(ci): checkout の版数コメントを v7.0.0 へ修正

### DIFF
--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout v4.3.0
+        # actions/checkout v7.0.0
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Markdown Lint via composite action


### PR DESCRIPTION
## 概要

Dependabot PR #61 で `actions/checkout` の SHA を v6.0.3 から v7.0.0（`9c091bb`）へ更新した際，直上の版数コメントが `# actions/checkout v4.3.0` の古いまま残っていた．実 SHA と整合させるためコメントを `v7.0.0` へ修正する．

## 背景

- SHA `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` は `actions/checkout` の `v7`／`v7.0.0` タグに対応する（裏取り済み）．
- 同型の修正を blog-private #86 で実施済みであり，その前例に倣う．

## 変更

- `.github/workflows/md-lint.yml` の版数コメントを `v4.3.0` → `v7.0.0` へ修正（1 行）．

🤖 Generated with [Claude Code](https://claude.com/claude-code)