### PR TITLE
feat(publish): 送信時に「続きを読む」(<!--more-->) を自動挿入

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ python scripts/publish.py drafts/2026-05-07-my-article.md --env-file /path/to/.e
 
 frontmatter の `categories` を読み，はてなのカテゴリーとして `<category term="...">` で送る．記述は配列とする．インラインフロー（`categories: [PHP, コミュニティ]`）とブロック形式（`- PHP` の各行）に対応する．空・未指定なら付けない．重複は順序を保って除く．推奨上限は 10 件で，超えると警告する（送信自体は妨げない）．`PUT` 更新でも毎回送り，はてな側を上書きする．本文からの選定は個人化版リポジトリ側の役割とし，本スクリプトは送信機構のみを担う．
 
+送信時は本文をはてなブログの Markdown 表示へ整形する．段落結合・段落間の余白・カード型リンクの埋め込み化に加え，「続きを読む」記法（`<!--more-->`）を自動挿入する．挿入位置は最初の `h2` 見出しの手前とする．導入本文が無い（先頭が見出し）場合や，既にマーカーがある場合は挿入しない（冪等）．記事ごとに無効化するには frontmatter へ `hatena_more: false` を書く．
+
 `--sync` は送信せず，はてな側のエントリ一覧を取得して正規化タイトル一致で `hatena_entry_id` を frontmatter へ記録する．送信済みだが ID 未記録の下書きを更新可能にするための回収に使う．同名（空白無視）が複数あれば取り違えを避けて記録しない．
 
 ```bash
@@ -255,7 +257,7 @@ python scripts/publish.py drafts/*.md --verify
 python scripts/publish.py --list-categories
 ```
 
-`--preview` は送信せず，はてな整形後の本文を標準出力へ出す．段落結合・段落間の余白・カード型リンクの埋め込み化の結果を，更新前の確認に使う．画像のアップロードは行わないため，画像記法は Markdown のまま残る．他のモード指定（`--sync`／`--verify`／`--list-categories`）とは併用できない．
+`--preview` は送信せず，はてな整形後の本文を標準出力へ出す．段落結合・段落間の余白・カード型リンクの埋め込み化・「続きを読む」の挿入の結果を，更新前の確認に使う．画像のアップロードは行わないため，画像記法は Markdown のまま残る．他のモード指定（`--sync`／`--verify`／`--list-categories`）とは併用できない．
 
 ```bash
 python scripts/publish.py drafts/*.md --preview

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -907,13 +907,17 @@ def _insert_more_block(blocks: list[str]) -> list[str]:
     `_drop_intro_heading` 適用後の最初の h2 で，その手前に導入本文がある場合のみ
     挿入する．先頭がいきなり h2（導入本文が無い）・h2 が無い・既にマーカーを含む
     場合は挿入しない（冪等）．挿入したマーカーは verbatim として後段でそのまま残る．
+
+    見出し判定は `_classify_block` と同じく各ブロックの先頭行で行う．見出し直後に
+    空行が無く本文が同じブロックに続く（`## 見出し\n本文`）場合も取りこぼさない．
+    コードフェンス内の `#` 行は `_classify_block` が verbatim と分類するため拾わない．
     """
     if any(_MORE_MARKER in b for b in blocks):
         return blocks
     for index, block in enumerate(blocks):
-        if "\n" in block:
+        if _classify_block(block) != "heading":
             continue
-        match = _HEADING_PATTERN.match(block.strip())
+        match = _HEADING_PATTERN.match(block.split("\n", 1)[0].strip())
         if match and len(match.group(1)) == 2:
             if index == 0:
                 # 先頭が h2 で導入本文が無い．折りたたむ導入が無いため挿入しない．

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -133,6 +133,14 @@ _HEADING_PATTERN = re.compile(r"^(#+)\s+(.*?)\s*$")
 # 書かずに本文から始める．ドラフトでは構成のため残し，送信時にここで落とす．
 _INTRO_HEADING_TITLES = {"導入", "はじめに"}
 
+# はてなブログの「続きを読む」（折りたたみ）記法．導入直後・最初の h2 の手前へ
+# 挿入し，一覧では導入までを表示させる運用を自動化する（`insert_more` で有効化）．
+_MORE_MARKER = "<!--more-->"
+
+# frontmatter のスカラーは `parse_frontmatter` が文字列で返す．真偽フラグの否定値と
+# して解釈する語（小文字化して比較）．該当時のみ既定有効の挙動を無効化する．
+_FALSE_FLAG_VALUES = frozenset({"false", "no", "off", "0"})
+
 
 def build_collection_url(username: str, blog_id: str) -> str:
     """コレクション URI（新規 POST 先・一覧取得先）を組み立てる．"""
@@ -320,6 +328,18 @@ def parse_frontmatter(
 
     body = "".join(lines[body_start:]).lstrip("\n")
     return fm_dict, body
+
+
+def _more_enabled(fm: dict[str, str | list[str]]) -> bool:
+    """frontmatter の `hatena_more` から「続きを読む」自動挿入の可否を判定する．
+
+    既定は有効（キーが無ければ挿入する）．`hatena_more: false` 等の否定値のときだけ
+    無効化する．`parse_frontmatter` はスカラーを文字列で返すため文字列で判定する．
+    """
+    value = fm.get("hatena_more")
+    if isinstance(value, str) and value.strip().lower() in _FALSE_FLAG_VALUES:
+        return False
+    return True
 
 
 def normalize_categories(raw: str | list[str] | None) -> list[str]:
@@ -880,6 +900,28 @@ def _drop_intro_heading(blocks: list[str]) -> list[str]:
     return blocks
 
 
+def _insert_more_block(blocks: list[str]) -> list[str]:
+    """最初の h2 見出しブロックの直前へ `_MORE_MARKER` ブロックを挿入する．
+
+    はてなブログの「続きを読む」を導入直後へ入れる手作業を自動化する．対象は
+    `_drop_intro_heading` 適用後の最初の h2 で，その手前に導入本文がある場合のみ
+    挿入する．先頭がいきなり h2（導入本文が無い）・h2 が無い・既にマーカーを含む
+    場合は挿入しない（冪等）．挿入したマーカーは verbatim として後段でそのまま残る．
+    """
+    if any(_MORE_MARKER in b for b in blocks):
+        return blocks
+    for index, block in enumerate(blocks):
+        if "\n" in block:
+            continue
+        match = _HEADING_PATTERN.match(block.strip())
+        if match and len(match.group(1)) == 2:
+            if index == 0:
+                # 先頭が h2 で導入本文が無い．折りたたむ導入が無いため挿入しない．
+                return blocks
+            return blocks[:index] + [_MORE_MARKER] + blocks[index:]
+    return blocks
+
+
 def _needs_spacer(prev: str, nxt: str) -> bool:
     """ブロック境界へ区切り行（`_PARAGRAPH_SPACER`）を挟むかどうかを判定する．
 
@@ -893,7 +935,7 @@ def _needs_spacer(prev: str, nxt: str) -> bool:
     return prev in media or nxt in media
 
 
-def transform_hatena_body(body: str) -> str:
+def transform_hatena_body(body: str, *, insert_more: bool = False) -> str:
     """本文をはてなブログの Markdown 表示に合わせて整形する（本文確定前処理）．
 
     はてなブログの Markdown では段落内の単純な改行が不要な半角スペースになる．
@@ -911,10 +953,16 @@ def transform_hatena_body(body: str) -> str:
     見出し・箇条書き・画像・コードフェンス・引用・HTML・表は変換しない．
     画像記法は後段の `transform_body_images` へ委ねるため，ここでは残す．
     先頭の導入見出し（h2）は著者の慣習に従い落とし，本文から始める．
+
+    `insert_more` が真のときは，最初の h2 見出しの手前へはてなの「続きを読む」
+    記法 `<!--more-->` を挿入する（`_insert_more_block` を参照）．導入本文が無い
+    場合や既にマーカーがある場合は挿入しない．
     """
     blocks = _drop_intro_heading(_split_body_blocks(body))
     if not blocks:
         return ""
+    if insert_more:
+        blocks = _insert_more_block(blocks)
 
     kinds = [_classify_block(b) for b in blocks]
     rendered = [_render_block(k, b) for k, b in zip(kinds, blocks)]
@@ -1081,8 +1129,9 @@ def publish_draft(
 
     # 本文確定前処理: はてなブログの Markdown 表示に合わせ，段落結合・段落間の
     # 余白・カード型リンクの埋め込み化を行う．画像処理より先に適用し，画像記法は
-    # そのまま残して後段へ委ねる．
-    body = transform_hatena_body(body)
+    # そのまま残して後段へ委ねる．「続きを読む」は既定で挿入し，frontmatter の
+    # `hatena_more: false` で記事ごとに無効化できる．
+    body = transform_hatena_body(body, insert_more=_more_enabled(fm))
 
     # 本文確定前処理: 本文中の Markdown 画像をフォトライフへ上げ figure へ置換する．
     # 送信が確定したドラフトに対してのみ実行し，抑止・スキップ時の無駄な通信を避ける．
@@ -1210,8 +1259,9 @@ def preview_drafts(draft_paths: list[Path]) -> None:
     parts: list[str] = []
     for path in draft_paths:
         text = path.read_text(encoding="utf-8")
-        _, body = parse_frontmatter(text, source=str(path))
-        parts.append(f"===== {path} =====\n{transform_hatena_body(body)}")
+        fm, body = parse_frontmatter(text, source=str(path))
+        rendered = transform_hatena_body(body, insert_more=_more_enabled(fm))
+        parts.append(f"===== {path} =====\n{rendered}")
     sys.stdout.buffer.write("\n".join(parts).encode("utf-8"))
     sys.stdout.buffer.flush()
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1748,6 +1748,14 @@ def test_transform_hatena_body_more_after_dropped_intro_heading() -> None:
     )
 
 
+def test_transform_hatena_body_more_before_heading_with_attached_body() -> None:
+    """見出し直後に空行が無い（見出しと本文が同一ブロック）場合も h2 を検出して挿入する．"""
+    body = "導入本文．\n\n## 見出し\n節本文．"
+    assert transform_hatena_body(body, insert_more=True) == (
+        "導入本文．  \n\n<!--more-->\n\n## 見出し\n節本文．\n"
+    )
+
+
 def test_publish_draft_applies_hatena_body_transform(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1703,6 +1703,51 @@ def test_transform_hatena_body_empty() -> None:
     assert transform_hatena_body("") == ""
 
 
+# ---------- transform_hatena_body（<!--more--> 自動挿入）----------
+
+
+def test_transform_hatena_body_inserts_more_before_first_heading() -> None:
+    """insert_more で最初の h2 見出しの直前へ <!--more--> を挿入する．"""
+    body = "導入本文．\n\n## 見出し\n\n節本文．"
+    assert transform_hatena_body(body, insert_more=True) == (
+        "導入本文．  \n\n<!--more-->\n\n## 見出し\n\n節本文．  \n"
+    )
+
+
+def test_transform_hatena_body_more_default_off() -> None:
+    """既定（insert_more 省略）では <!--more--> を挿入しない．"""
+    body = "導入本文．\n\n## 見出し"
+    assert "<!--more-->" not in transform_hatena_body(body)
+
+
+def test_transform_hatena_body_more_idempotent_when_present() -> None:
+    """本文に既に <!--more--> があれば二重挿入しない（冪等）．"""
+    body = "導入．\n\n<!--more-->\n\n## 見出し"
+    assert transform_hatena_body(body, insert_more=True) == (
+        "導入．  \n\n<!--more-->\n\n## 見出し\n"
+    )
+
+
+def test_transform_hatena_body_more_skipped_without_heading() -> None:
+    """h2 見出しが無ければ <!--more--> を挿入しない．"""
+    body = "本文だけ．\n\n続き．"
+    assert "<!--more-->" not in transform_hatena_body(body, insert_more=True)
+
+
+def test_transform_hatena_body_more_skipped_when_heading_leads() -> None:
+    """先頭がいきなり h2（導入本文が無い）なら <!--more--> を挿入しない．"""
+    body = "## まとめ\n\n本文．"
+    assert "<!--more-->" not in transform_hatena_body(body, insert_more=True)
+
+
+def test_transform_hatena_body_more_after_dropped_intro_heading() -> None:
+    """導入見出しを落とした後の最初の h2 の直前へ挿入する．"""
+    body = "## 導入\n\n導入本文．\n\n## 節\n\n節本文．"
+    assert transform_hatena_body(body, insert_more=True) == (
+        "導入本文．  \n\n<!--more-->\n\n## 節\n\n節本文．  \n"
+    )
+
+
 def test_publish_draft_applies_hatena_body_transform(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1731,6 +1776,57 @@ def test_publish_draft_applies_hatena_body_transform(
     assert "[https://note.com/tomio2480/n/abc:embed:cite]" in body_xml
 
 
+def test_publish_draft_inserts_more_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """既定で送信本文の最初の h2 直前へ <!--more--> が挿入される．"""
+    draft = tmp_path / "2026-06-21-more.md"
+    draft.write_text(
+        '---\ndraft_of: "折りたたみ記事"\nhatena_entry_id: "778"\n---\n'
+        "導入本文．\n\n## 見出し\n\n節本文．\n",
+        encoding="utf-8",
+    )
+
+    sent: dict[str, bytes] = {}
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        sent["body"] = xml
+        return b"<id>tag:...-778</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    publish.publish_draft(draft, "u", "b", "k")
+
+    body_xml = sent["body"].decode("utf-8")
+    # 送信 XML では本文が html.escape される（はてな受信時に復元される）ため，
+    # マーカーはエスケープ形で載る．
+    assert "&lt;!--more--&gt;\n\n## 見出し" in body_xml
+
+
+def test_publish_draft_more_opt_out_via_frontmatter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """frontmatter の hatena_more: false で <!--more--> 挿入を無効化できる．"""
+    draft = tmp_path / "2026-06-21-nomore.md"
+    draft.write_text(
+        '---\ndraft_of: "折りたたみ無効"\nhatena_entry_id: "779"\n'
+        "hatena_more: false\n---\n"
+        "導入本文．\n\n## 見出し\n\n節本文．\n",
+        encoding="utf-8",
+    )
+
+    sent: dict[str, bytes] = {}
+
+    def fake_send(url, xml, username, api_key, method):  # noqa: ANN001
+        sent["body"] = xml
+        return b"<id>tag:...-779</id>"
+
+    monkeypatch.setattr(publish, "_send_entry", fake_send)
+    publish.publish_draft(draft, "u", "b", "k")
+
+    # エスケープ後の形でも現れないことを確認する（生文字列では XML 上に元々出ない）．
+    assert "&lt;!--more--&gt;" not in sent["body"].decode("utf-8")
+
+
 # ---------- preview_drafts ----------
 
 
@@ -1749,3 +1845,32 @@ def test_preview_drafts_writes_utf8_bytes(
     out = capsysbinary.readouterr().out.decode("utf-8")
     assert "本文 — つづき．  " in out
     assert "[https://example.com/x:embed:cite]" in out
+
+
+def test_preview_drafts_reflects_more_insertion(
+    tmp_path: Path, capsysbinary: pytest.CaptureFixture
+) -> None:
+    """プレビューにも <!--more--> の自動挿入が反映される．"""
+    draft = tmp_path / "2026-06-21-preview-more.md"
+    draft.write_text(
+        '---\ndraft_of: "折りたたみ確認"\n---\n導入本文．\n\n## 見出し\n\n節本文．\n',
+        encoding="utf-8",
+    )
+    publish.preview_drafts([draft])
+    out = capsysbinary.readouterr().out.decode("utf-8")
+    assert "<!--more-->\n\n## 見出し" in out
+
+
+def test_preview_drafts_more_opt_out_via_frontmatter(
+    tmp_path: Path, capsysbinary: pytest.CaptureFixture
+) -> None:
+    """プレビューでも hatena_more: false で <!--more--> 挿入を無効化できる．"""
+    draft = tmp_path / "2026-06-21-preview-nomore.md"
+    draft.write_text(
+        '---\ndraft_of: "折りたたみ無効"\nhatena_more: false\n---\n'
+        "導入本文．\n\n## 見出し\n\n節本文．\n",
+        encoding="utf-8",
+    )
+    publish.preview_drafts([draft])
+    out = capsysbinary.readouterr().out.decode("utf-8")
+    assert "<!--more-->" not in out


### PR DESCRIPTION
## 概要

`scripts/publish.py` の `transform_hatena_body` に，はてなブログの「続きを読む」記法（`<!--more-->`）の自動挿入を実装する．公開済み記事の再検証で，複数記事にわたり一定位置（導入直後・最初の `h2` の手前）へ手挿入する反復が確認されたため，送信時整形で自動化する．

Closes #62

## 実装

- 挿入位置：`_drop_intro_heading` 適用後の**最初の `h2` 見出しの直前**．
- 冪等性：本文に既に `<!--more-->` がある・`h2` が無い・先頭がいきなり `h2`（導入本文が無い）場合は挿入しない．
- オプトアウト：frontmatter の `hatena_more: false` で記事ごとに無効化（既定は挿入）．`parse_frontmatter` はスカラーを文字列で返すため，`_more_enabled` で否定値（`false`／`no`／`off`／`0`）を判定する．
- 反映範囲：`publish_draft` の送信本文と `--preview` の双方．
- `transform_hatena_body(body, *, insert_more=False)` と引数を追加し，既定は従来どおり無挿入（既存テストへ影響なし）．

## 送信時のエスケープ

送信 XML では本文が `html.escape` されるため，マーカーは `&lt;!--more--&gt;` として載る（はてな受信時に復元される）．テストはこのエスケープ形で検証する．

## テスト

- TDD（Red→Green→Refactor）で実装．新規テスト 10 件を追加．
  - `transform_hatena_body` の挿入・既定無挿入・冪等・`h2` 無し・先頭見出し・導入見出し落とし後の 6 観点．
  - `publish_draft` の既定挿入・`hatena_more: false` オプトアウトの 2 観点．
  - `--preview` の反映・オプトアウトの 2 観点．
- 全 398 テスト pass．`ruff check` pass．

## ドキュメント

- `README.md` へ送信時整形（`<!--more-->` 挿入・`hatena_more` オプトアウト）を追記．`--preview` の説明も更新．

🤖 Generated with [Claude Code](https://claude.com/claude-code)